### PR TITLE
Fixed incorrect environment variable on line 141

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The full build process is:
 
 The following is an example of valid environment variables:
 
-SET USD_LOCAITON=C:\src\usd\builds\v0.8.4\monolithic_no-python\
+SET USD_LOCATION=C:\src\usd\builds\v0.8.4\monolithic_no-python\
 SET USD_LOCATION_PYTHON=C:\src\usd\builds\v0.8.4\monolithic\
 
 The following are the USD build commands used to generate the two build paths noted above:


### PR DESCRIPTION
Example valid environment variable USD_LOCATION was spelt USD_LOCAITON causing potential confusion.

Only a small typo but could trip up new users.