### PR TITLE
Initial Test and Continuous Integration with Yamato

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,6 +1,7 @@
 editors:
   - version: 2019.1.0b2
-
+  - version: 2018.3.4f1
+  - version: trunk
 platforms:
   - name: win
     type: Unity::VM

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,5 +1,5 @@
 editors:
-  - version: 2018.3
+  - version: trunk
 platforms:
   - name: win
     type: Unity::VM
@@ -19,9 +19,9 @@ platforms:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
-      - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
-      - upm-ci package pack --package-path package/com.unity.formats.usd
-      - upm-ci package test --unity-version {{ editor.version }} --package-path package/com.unity.formats.usd
+    - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - upm-ci package pack --package-path package/com.unity.formats.usd
+    - upm-ci package test  --package-path package/com.unity.formats.usd  --unity-version {{ editor.version }}
   triggers:
     branches:
        only:
@@ -31,12 +31,7 @@ platforms:
   artifacts:
     logs.zip:
       paths:
-        - "upm-ci~/logs/**/*"
         - "upm-ci~/test-results/**/*"
-    artifacts.zip:
-      paths:
-        - "upm-ci~/packages/**/*"
-        - "upm-ci~/templates/**/*"
 {% endfor %}
 {% endfor %}
 
@@ -48,25 +43,21 @@ run_preview_verified_staging:
     flavor: m1.large
     name: Runner
   commands:
-    # Install ci tools dependencies
-    - git clone --single-branch --branch feat/PAI-434-template-test git@gitlab.cds.internal.unity3d.com:upm-packages/project-templates/upm-template-utils.git
-    - npm install upm-template-utils
-    - node upm-template-utils/index.js template publish
+    - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - upm-ci package pack
+    - upm-ci package publish --registry staging
   triggers:
     tags:
       only:
         - /^(v|V)[0-9].[0-9].[0-9]/
   artifacts:
-    logs.zip:
+    artifacts.zip:
       paths:
-        - "upm-ci~/logs/**/*"
-        - "upm-ci~/test-results/**/*"
-    Package.zip:
-      paths:
-        - "upm-ci~/package/*.tgz"
+        - "upm-ci~/packages/*.tgz"
   dependencies:
   {% for editor in editors %}
   {% for platform in platforms %}
     - .yamato/upm-ci.yml#{{ platform.name }}_{{ editor.version }}
   {% endfor %}  
   {% endfor %}
+

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,5 +1,6 @@
 editors:
-  - version: trunk
+  - version: 2019.1.0b2
+
 platforms:
   - name: win
     type: Unity::VM

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,5 +1,5 @@
 editors:
-  - version: 2018.3
+  - version: trunk
 platforms:
   - name: win
     type: Unity::VM

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,5 +1,7 @@
 editors:
-  - version: 2019.1.0b4
+  - version: 2019.1
+  - version: 2018.3
+  - version: trunk
 platforms:
   - name: win
     type: Unity::VM

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,7 +1,5 @@
 editors:
-  - version: 2019.1.0b2
-  - version: 2018.3.4f1
-  - version: trunk
+  - version: 2018.3
 platforms:
   - name: win
     type: Unity::VM
@@ -21,9 +19,9 @@ platforms:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
-    - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
-    - upm-ci package pack --package-path package/com.unity.formats.usd
-    - upm-ci package test  --package-path package/com.unity.formats.usd  --unity-version {{ editor.version }}
+      - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
+      - upm-ci package pack --package-path package/com.unity.formats.usd
+      - upm-ci package test --unity-version {{ editor.version }} --package-path package/com.unity.formats.usd
   triggers:
     branches:
        only:
@@ -33,7 +31,12 @@ platforms:
   artifacts:
     logs.zip:
       paths:
+        - "upm-ci~/logs/**/*"
         - "upm-ci~/test-results/**/*"
+    artifacts.zip:
+      paths:
+        - "upm-ci~/packages/**/*"
+        - "upm-ci~/templates/**/*"
 {% endfor %}
 {% endfor %}
 
@@ -45,17 +48,22 @@ run_preview_verified_staging:
     flavor: m1.large
     name: Runner
   commands:
-    - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
-    - upm-ci package pack
-    - upm-ci package publish --registry staging
+    # Install ci tools dependencies
+    - git clone --single-branch --branch feat/PAI-434-template-test git@gitlab.cds.internal.unity3d.com:upm-packages/project-templates/upm-template-utils.git
+    - npm install upm-template-utils
+    - node upm-template-utils/index.js template publish
   triggers:
     tags:
       only:
         - /^(v|V)[0-9].[0-9].[0-9]/
   artifacts:
-    artifacts.zip:
+    logs.zip:
       paths:
-        - "upm-ci~/packages/*.tgz"
+        - "upm-ci~/logs/**/*"
+        - "upm-ci~/test-results/**/*"
+    Package.zip:
+      paths:
+        - "upm-ci~/package/*.tgz"
   dependencies:
   {% for editor in editors %}
   {% for platform in platforms %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,0 +1,72 @@
+editors:
+  - version: 2018.3
+platforms:
+  - name: win
+    type: Unity::VM
+    image: package-ci/win10:latest
+    flavor: m1.large
+  - name: mac
+    type: Unity::VM::osx
+    image: buildfarm/mac:stable
+    flavor: m1.mac
+---
+{% for editor in editors %}
+{% for platform in platforms %}
+{{ platform.name }}_{{ editor.version }}:
+  name : Build and Test version {{ editor.version }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  commands:
+      - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
+      - upm-ci package pack --package-path package/com.unity.formats.usd
+      - upm-ci package test --unity-version {{ editor.version }} --package-path package/com.unity.formats.usd
+  triggers:
+    branches:
+       only:
+         - "/.*/"
+       except:
+         - master
+  artifacts:
+    logs.zip:
+      paths:
+        - "upm-ci~/logs/**/*"
+        - "upm-ci~/test-results/**/*"
+    artifacts.zip:
+      paths:
+        - "upm-ci~/packages/**/*"
+        - "upm-ci~/templates/**/*"
+{% endfor %}
+{% endfor %}
+
+run_preview_verified_staging:
+  name: Preview and Verified Packages to Staging
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:latest
+    flavor: m1.large
+    name: Runner
+  commands:
+    # Install ci tools dependencies
+    - git clone --single-branch --branch feat/PAI-434-template-test git@gitlab.cds.internal.unity3d.com:upm-packages/project-templates/upm-template-utils.git
+    - npm install upm-template-utils
+    - node upm-template-utils/index.js template publish
+  triggers:
+    tags:
+      only:
+        - /^(v|V)[0-9].[0-9].[0-9]/
+  artifacts:
+    logs.zip:
+      paths:
+        - "upm-ci~/logs/**/*"
+        - "upm-ci~/test-results/**/*"
+    Package.zip:
+      paths:
+        - "upm-ci~/package/*.tgz"
+  dependencies:
+  {% for editor in editors %}
+  {% for platform in platforms %}
+    - .yamato/upm-ci.yml#{{ platform.name }}_{{ editor.version }}
+  {% endfor %}  
+  {% endfor %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,5 +1,5 @@
 editors:
-  - version: trunk
+  - version: 2019.1.0b4
 platforms:
   - name: win
     type: Unity::VM

--- a/TestProject/Packages/manifest.json
+++ b/TestProject/Packages/manifest.json
@@ -37,5 +37,8 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
-  }
+  },
+  "testables": [
+    "com.unity.formats.usd"
+  ]
 }

--- a/package/com.unity.formats.usd/CHANGELOG.md
+++ b/package/com.unity.formats.usd/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changes in usd-unitysdk for Unity
+
+## [1.0.0-preview.1] - 2019-02-20
+### Changes
+- Initial creation of the package

--- a/package/com.unity.formats.usd/CHANGELOG.md.meta
+++ b/package/com.unity.formats.usd/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5a235092b64514dd88fac61b07524c7f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Documentation~/USD.md
+++ b/package/com.unity.formats.usd/Documentation~/USD.md
@@ -1,3 +1,7 @@
 # USD for Unity
 
-Somce documentation
+The Unity USD package contains a set of libraries designed to support the use of Pixar's Universal Scene Description (USD) in Unity. The goal of this package is to make it maximally easy to integrate USD using native Unity & C# data types with a familiar serialization paradigm and little prior knowledge of USD. USD enables round-trip asset workflows between digital content creation tools like Maya, 3ds Max, Houdini, Katana, Nuke, Modo, Sketchup, Substance Designer, and Substance Painter.
+
+Unlike other asset file formats, Universal Scene Description is designed to support an entire asset pipeline and to enable teams to work in parallel using asset references and overrides. 
+
+This package includes ready-to-use binaries and examples to allow anyone to easily jump-in.

--- a/package/com.unity.formats.usd/Documentation~/USD.md
+++ b/package/com.unity.formats.usd/Documentation~/USD.md
@@ -1,0 +1,3 @@
+# USD for Unity
+
+Somce documentation

--- a/package/com.unity.formats.usd/Tests.meta
+++ b/package/com.unity.formats.usd/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3cca72866bddf40b8a7c1f200fe1bf44
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/.tests.json
+++ b/package/com.unity.formats.usd/Tests/.tests.json
@@ -1,0 +1,3 @@
+{
+	"createSeparatePackage": true
+}

--- a/package/com.unity.formats.usd/Tests/.tests.json
+++ b/package/com.unity.formats.usd/Tests/.tests.json
@@ -1,3 +1,3 @@
 {
-	"createSeparatePackage": true
+	"createSeparatePackage": false
 }

--- a/package/com.unity.formats.usd/Tests/Editor.meta
+++ b/package/com.unity.formats.usd/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b4051ad1f450a4400a54de71e4267e7d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/Editor/EditorTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/EditorTests.cs
@@ -10,3 +10,4 @@ namespace Unity.Formats.USD.Tests
         }
     }
 }
+

--- a/package/com.unity.formats.usd/Tests/Editor/EditorTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/EditorTests.cs
@@ -1,0 +1,12 @@
+using NUnit.Framework;
+
+namespace Unity.Formats.USD.Tests
+{
+    public class EditorTests
+    {
+        [Test]
+        public void DummyTest()
+        {
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Editor/EditorTests.cs.meta
+++ b/package/com.unity.formats.usd/Tests/Editor/EditorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06f7436471c41426785f7e04518a9c90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/Editor/Unity.Formats.USD.Tests.Editor.asmdef
+++ b/package/com.unity.formats.usd/Tests/Editor/Unity.Formats.USD.Tests.Editor.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Unity.Formats.USD.Tests.Editor",
+    "references": [
+        "Unity.Formats.USD.Runtime"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false
+}

--- a/package/com.unity.formats.usd/Tests/Editor/Unity.Formats.USD.Tests.Editor.asmdef.meta
+++ b/package/com.unity.formats.usd/Tests/Editor/Unity.Formats.USD.Tests.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e50fcb8f70e44487fae2be8974997e9c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/Runtime.meta
+++ b/package/com.unity.formats.usd/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 83e48fa9eeb714ec58e966eac56290ba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/Runtime/RuntimeTests.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/RuntimeTests.cs
@@ -69,8 +69,9 @@ namespace Unity.Formats.USD.Tests
                 {
                     File.Delete(file);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
+                    // ignored
                 }
             }
         }

--- a/package/com.unity.formats.usd/Tests/Runtime/RuntimeTests.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/RuntimeTests.cs
@@ -77,3 +77,4 @@ namespace Unity.Formats.USD.Tests
         }
     }
 }
+

--- a/package/com.unity.formats.usd/Tests/Runtime/RuntimeTests.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/RuntimeTests.cs
@@ -1,14 +1,78 @@
+using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
+using USD.NET;
+using Scene = USD.NET.Scene;
 
 namespace Unity.Formats.USD.Tests
 {
-    public class RuntimeTests
+    public class SanityTest
     {
-        [UnityTest]
-        public IEnumerator DummyTest()
+        List<string> filesToDelete = new List<string>();
+        class MyCustomData : SampleBase 
         {
-            yield return null;
+            public string aString;
+            public int[] anArrayOfInts;
+            public Bounds aBoundingBox;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            InitUsd.Initialize();
+        }
+
+        [Test]
+        public void CanWriteCustomData()
+        {
+            string usdFile = System.IO.Path.Combine(UnityEngine.Application.dataPath, "sceneFile.usda");
+            filesToDelete.Add(usdFile);
+            // Populate Values.
+            var value = new MyCustomData();
+            value.aString = "IT'S ALIIIIIIIIIIIIIVE!";
+            value.anArrayOfInts = new int[] { 1, 2, 3, 4 };
+            value.aBoundingBox = new UnityEngine.Bounds();
+
+            // Writing the value.
+            var scene = Scene.Create(usdFile);
+            scene.Time = 1.0;
+            scene.Write("/someValue", value);
+            Debug.Log(scene.Stage.GetRootLayer().ExportToString());
+            scene.Save();
+            scene.Close();
+            
+            Assert.IsTrue(File.Exists(usdFile));
+
+            // Reading the value.
+            Debug.Log(usdFile);
+            var newValue = new MyCustomData();
+            scene = Scene.Open(usdFile);
+            scene.Time = 1.0;
+            scene.Read("/someValue", newValue);
+            
+            Assert.AreEqual(value.aString, newValue.aString);
+            
+            scene.Close();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var file in filesToDelete) 
+            {
+                try
+                {
+                    File.Delete(file);
+                }
+                catch (Exception e)
+                {
+                }
+            }
         }
     }
 }

--- a/package/com.unity.formats.usd/Tests/Runtime/RuntimeTests.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/RuntimeTests.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using UnityEngine.TestTools;
+
+namespace Unity.Formats.USD.Tests
+{
+    public class RuntimeTests
+    {
+        [UnityTest]
+        public IEnumerator DummyTest()
+        {
+            yield return null;
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Runtime/RuntimeTests.cs.meta
+++ b/package/com.unity.formats.usd/Tests/Runtime/RuntimeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9acf37ef0937b4b0387de27932362435
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/Runtime/Unity.Formats.USD.Tests.asmdef
+++ b/package/com.unity.formats.usd/Tests/Runtime/Unity.Formats.USD.Tests.asmdef
@@ -1,0 +1,17 @@
+{
+    "name": "Unity.Formats.USD.Tests",
+    "references": [
+        "Unity.Formats.USD.Runtime"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor",
+        "LinuxStandalone64",
+        "macOSStandalone",
+        "WindowsStandalone64"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false
+}

--- a/package/com.unity.formats.usd/Tests/Runtime/Unity.Formats.USD.Tests.asmdef.meta
+++ b/package/com.unity.formats.usd/Tests/Runtime/Unity.Formats.USD.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e0bc64a4d994c45c1af4e32e2d1b6d1f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/package.json
+++ b/package/com.unity.formats.usd/package.json
@@ -2,7 +2,7 @@
     "dependencies": {
         "com.unity.timeline" : "1.0.0"
     },
-    "description": "The Unity USD package contains a set of libraries designed to support the use of Pixar's Universal Scene Description (USD) in Unity. The goal of this package is to make it maximally easy to integrate USD using native Unity & C# data types with a familiar serialization paradigm and little prior knowledge of USD. USD enables round-trip asset workflows between digital content creation tools like Maya, 3ds Max, Houdini, Katana, Nuke, Modo, Sketchup, Substance Designer, and Substance Painter. \n\nUnlike other asset file formats, Universal Scene Description is designed to support an entire asset pipeline and to enable teams to work in parallel using asset references and overrides. \n\nThis package includes ready-to-use binaries and examples to allow anyone to easily jump-in (see Examples folder).",
+    "description": "The Unity USD package contains a set of libraries designed to support the use of Pixar's Universal Scene Description (USD) in Unity. The goal of this package is to make it maximally easy to integrate USD using native Unity & C# data types with a familiar serialization paradigm and little prior knowledge of USD. USD enables round-trip asset workflows between digital content creation tools like Maya, 3ds Max, Houdini, Katana, Nuke, Modo, Sketchup, Substance Designer, and Substance Painter. \n\nUnlike other asset file formats, Universal Scene Description is designed to support an entire asset pipeline and to enable teams to work in parallel using asset references and overrides. \n\nThis package includes ready-to-use binaries and examples to allow anyone to easily jump-in.",
     "displayName": "USD",
     "keywords": [
       "usd",


### PR DESCRIPTION
*Converted HelloUsd into a test (the most trivial USD operation I found around)
*Added a dummy Documentation~/USD.md with same info from package.json (needed this to make validation green)
*Added Yamato CI config. You can run it at: https://yamato.prd.cds.internal.unity3d.com/jobs/86-usd-unity-sdk . 2019.1 will fail on Mac because of a bug fix in Unity that did not make it in just yet.