### PR TITLE
Serialize import options

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImportOptions.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImportOptions.cs
@@ -43,6 +43,7 @@ namespace Unity.Formats.USD {
   /// <summary>
   /// Indicates how values are imported from the given scene into a UnityEngine.Mesh object.
   /// </summary>
+  [System.Serializable]
   public class MeshImportOptions {
 
     /// <summary>

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/MaterialMap.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/MaterialMap.cs
@@ -52,15 +52,34 @@ namespace Unity.Formats.USD {
     /// </summary>
     public bool useOriginalShaderIfAvailable;
 
+    Material m_displayColorMaterial, m_specularWorkflowMaterial, m_metallicWorkflowMaterial;
+
     /// <summary>
     /// A material to use when no material could be found.
     /// </summary>
-    public Material DisplayColorMaterial { get; set; }
+    public Material DisplayColorMaterial { 
+      get {
+        if (m_displayColorMaterial == null) InstantiateMaterials();
+        return m_displayColorMaterial;
+      } 
+      set {m_displayColorMaterial = value;} 
+    }
+    public Material SpecularWorkflowMaterial { 
+      get { 
+        if (m_specularWorkflowMaterial == null) InstantiateMaterials();
+        return m_specularWorkflowMaterial;
+      } 
+      set {m_specularWorkflowMaterial = value;}
+    }
+    public Material MetallicWorkflowMaterial { 
+      get { 
+        if (m_metallicWorkflowMaterial == null) InstantiateMaterials();
+        return m_metallicWorkflowMaterial;
+      }
+      set {m_metallicWorkflowMaterial = value;}
+    }
 
-    public Material SpecularWorkflowMaterial { get; set; }
-    public Material MetallicWorkflowMaterial { get; set; }
-
-    public MaterialMap() {
+    void InstantiateMaterials() {
       var pipeline = UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset;
       if (!pipeline) {
         // Fallback to the built-in render pipeline, assume Standard PBS shader.

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImportOptions.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImportOptions.cs
@@ -67,6 +67,7 @@ namespace Unity.Formats.USD {
   /// <summary>
   /// Indicates how the scene should be imported from USD to Unity.
   /// </summary>
+  [System.Serializable]
   public class SceneImportOptions {
 
     /// <summary>
@@ -134,6 +135,7 @@ namespace Unity.Formats.USD {
     /// <summary>
     /// A set of registered mappings from USD shader ID to Unity material.
     /// </summary>
+    [System.NonSerialized]
     public MaterialMap materialMap = new MaterialMap();
 
     /// <summary>


### PR DESCRIPTION
 SceneImportOptions and MeshImportOptions serialize correctly, needed for persistent GameObjects that load USD.