### PR TITLE
Fix UsdAssetEditor Simple UI to take text input to file and root fields. added file browser

### DIFF
--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
@@ -175,12 +175,22 @@ namespace Unity.Formats.USD {
 
       EditorGUILayout.BeginHorizontal();
       EditorGUILayout.PrefixLabel("USD File");
-      EditorGUILayout.LabelField(usdAsset.usdFullPath, EditorStyles.textField);
+      usdAsset.usdFullPath = EditorGUILayout.TextField(usdAsset.usdFullPath, EditorStyles.textField);
+      if(GUILayout.Button("...")) {
+          string lastDir;
+          if (string.IsNullOrEmpty(usdAsset.usdFullPath))
+              lastDir = System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments);
+          else
+              lastDir =  Path.GetDirectoryName(usdAsset.usdFullPath);
+          string importFilepath = EditorUtility.OpenFilePanelWithFilters("Usd Asset", lastDir, new string[] { "Usd","us*"});
+          if ( string.IsNullOrEmpty(importFilepath)) return;
+          usdAsset.usdFullPath = importFilepath;    
+      }
       EditorGUILayout.EndHorizontal();
 
       EditorGUILayout.BeginHorizontal();
       EditorGUILayout.PrefixLabel("USD Root Path");
-      EditorGUILayout.LabelField(usdAsset.m_usdRootPath, EditorStyles.textField);
+      usdAsset.m_usdRootPath = EditorGUILayout.TextField(usdAsset.m_usdRootPath, EditorStyles.textField);
       EditorGUILayout.EndHorizontal();
 
       GUILayout.Label("Import Settings", EditorStyles.boldLabel);

--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
@@ -127,13 +127,21 @@ namespace Unity.Formats.USD {
         style.wordWrap = true;
         EditorGUILayout.LabelField("Edit prefab for destructive operations", style);
       } else {
-        if (GUILayout.Button(new GUIContent(m_reimportButton, "Reimport from USD (destructive)"), buttonStyle)) {
-          if (EditorUtility.DisplayDialog("Reimport from Source", "Destroy and rebuild all USD objects?\n\n"
-                  + "Any GameObject with a UsdPrimSource will be destroyed and reimported.",
-                "OK", "Cancel")) {
+        if (usdAsset.transform.childCount == 0) {
+          if (GUILayout.Button(new GUIContent(m_reimportButton, "Import from USD"), buttonStyle)) {
             ReloadFromUsd(usdAsset, forceRebuild: true);
           }
+        } else {
+          if (GUILayout.Button(new GUIContent(m_reimportButton, "Reimport from USD (destructive)"), buttonStyle)) {
+            if (EditorUtility.DisplayDialog("Reimport from Source", "Destroy and rebuild all USD objects?\n\n"
+                    + "Any GameObject with a UsdPrimSource will be destroyed and reimported.",
+                  "OK", "Cancel")) {
+              ReloadFromUsd(usdAsset, forceRebuild: true);
+            }
+          }
         }
+
+        EditorGUI.BeginDisabledGroup(usdAsset.transform.childCount == 0);
         if (GUILayout.Button(new GUIContent(m_trashButton, "Remove USD Contents (destructive)"), buttonStyle)) {
           if (EditorUtility.DisplayDialog("Clear Contents", "Destroy all USD objects?\n\n"
                   + "Any GameObject with a UsdPrimSource will be destroyed. "
@@ -149,6 +157,7 @@ namespace Unity.Formats.USD {
             DetachFromUsd(usdAsset);
           }
         }
+        EditorGUI.EndDisabledGroup();
       }
       GUILayout.FlexibleSpace();
       GUILayout.EndHorizontal();


### PR DESCRIPTION
previously the Simple UI did not allow editing of the file path or usd root.