### PR TITLE
Fix timeline clips

### DIFF
--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
@@ -19,7 +19,7 @@ using UnityEditor.Experimental.AssetImporters;
 
 namespace Unity.Formats.USD {
   [CustomEditor(typeof(UsdAsset))]
-  public class UsdAssetEditor : ScriptedImporterEditor {
+  public class UsdAssetEditor : Editor {
     private readonly string[] kTabNames = new string[] { "Simple", "Advanced" };
     private int m_tab;
 
@@ -38,8 +38,8 @@ namespace Unity.Formats.USD {
       Custom = 4
     }
 
-    public override void OnEnable() {
-      base.OnEnable();
+    public void OnEnable() {
+
       if (!m_usdLogo) {
         var script = MonoScript.FromScriptableObject(this);
         var path = AssetDatabase.GetAssetPath(script);

--- a/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdPlayableAsset.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdPlayableAsset.cs
@@ -19,7 +19,7 @@ using UnityEngine.Timeline;
 namespace Unity.Formats.USD {
 
   [System.Serializable]
-  public class UsdPlayableAsset : PlayableAsset {
+  public class UsdPlayableAsset : PlayableAsset, ITimelineClipAsset {
     private UsdAsset m_sourceUsdAsset;
 
     [Tooltip("USD Player to Control")]


### PR DESCRIPTION
To specify clipCaps, one should implement ITimelineClipAsset.
Snuck in another fix: UsdAssetEditor Inherited from ScriptedImporter, but the UsdAsset is not an importer. A change in trunk makes it spew errors in the console.