### PR TITLE
Root prim fix

### DIFF
--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdMenu.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdMenu.cs
@@ -149,15 +149,17 @@ namespace Unity.Formats.USD {
 #endif
 
     static private pxr.SdfPath GetDefaultRoot(Scene scene) {
-      var defPrim = scene.Stage.GetDefaultPrim();
-      if (defPrim) {
-        return defPrim.GetPath();
-      }
+      // We can't safely assume the default prim is the model root, because Alembic files will
+      // always have a default prim set arbitrarily.
+
+      // If there is only one root prim, reference this prim.
       var children = scene.Stage.GetPseudoRoot().GetChildren().ToList();
-      if (children.Count > 0) {
+      if (children.Count == 1) {
         return children[0].GetPath();
       }
 
+      // Otherwise there are 0 or many root prims, in this case the best option is to reference
+      // them all, to avoid confusion.
       return pxr.SdfPath.AbsoluteRootPath();
     }
 

--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
@@ -68,10 +68,6 @@ namespace Unity.Formats.USD {
     public PayloadPolicy m_payloadPolicy = PayloadPolicy.DontLoadPayloads;
 
     [HideInInspector]
-    [Tooltip("Memorizes which attributes change over time, to speed up playback (trades time for memory)")]
-    public bool m_usdVariabilityCache = true;
-
-    [HideInInspector]
     public bool m_importHierarchy = true;
 
     // ----------------------------------------------------------------------------------------- //
@@ -195,6 +191,9 @@ namespace Unity.Formats.USD {
     public bool m_debugShowSkeletonBindPose;
     public bool m_debugShowSkeletonRestPose;
     public bool m_debugPrintVariabilityCache;
+
+    [Tooltip("Memorizes which attributes change over time, to speed up playback (trades time for memory)")]
+    public bool m_usdVariabilityCache = true;
 
     [HideInInspector]
     public BasisTransformation LastHandedness;

--- a/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdPlayableAsset.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdPlayableAsset.cs
@@ -24,12 +24,11 @@ namespace Unity.Formats.USD {
 
     [Tooltip("USD Player to Control")]
     public ExposedReference<UsdAsset> SourceUsdAsset;
-    public string UsdRootPath;
 
     public ClipCaps clipCaps { get { return ClipCaps.Extrapolation | ClipCaps.Looping | ClipCaps.SpeedMultiplier | ClipCaps.ClipIn; } }
 
-    public UsdAsset GetUsdAsset() {
-      m_sourceUsdAsset.m_usdRootPath = UsdRootPath;
+    public UsdAsset GetUsdAsset(string usdRootPath) {
+      m_sourceUsdAsset.m_usdRootPath = usdRootPath;
       return m_sourceUsdAsset;
     }
 
@@ -40,7 +39,6 @@ namespace Unity.Formats.USD {
 
       if (m_sourceUsdAsset != null) {
         behaviour.playableAsset = this;
-        UsdRootPath = m_sourceUsdAsset.m_usdRootPath;
         name = System.IO.Path.GetFileName(m_sourceUsdAsset.usdFullPath);
       }
 

--- a/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdPlayableBehaviour.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdPlayableBehaviour.cs
@@ -49,9 +49,6 @@ namespace Unity.Formats.USD {
     public override void ProcessFrame(Playable playable, FrameData info, object playerData) {
       if (playableAsset == null) { return; }
 
-      var sourceUsdAsset = playableAsset.GetUsdAsset();
-      if (sourceUsdAsset == null) { return; }
-
       var targetUsdAsset = playerData as UsdAsset;
       if (targetUsdAsset == null) {
         if (m_errorOnce) {
@@ -62,6 +59,9 @@ namespace Unity.Formats.USD {
       } else {
         m_errorOnce = true;
       }
+
+      var sourceUsdAsset = playableAsset.GetUsdAsset(targetUsdAsset.m_usdRootPath);
+      if (sourceUsdAsset == null) { return; }
 
       if (!targetUsdAsset.isActiveAndEnabled) {
         return;


### PR DESCRIPTION
The old logic would always attempt to set a root prim, the new logic only sets the root when only a single root exists. This also moves the variability cache option into the debug section of the UsdAsset inspector.