### PR TITLE
Payloads: Improve load state tracking

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdPayload.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdPayload.cs
@@ -22,6 +22,8 @@ namespace Unity.Formats.USD {
     private bool m_isLoaded = true;
 
     // Variable used to track dirty load state.
+    [SerializeField]
+    [HideInInspector]
     private bool m_wasLoaded = true;
 
     /// <summary>


### PR DESCRIPTION
There is a deeper bug here, but this at least makes the load/unload menu items behave /more/ consistently, though there is a complex corner case which can cause them to stop working.