### PR TITLE
UsdSkel Import: Find nested skeleton relationships

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/HierarchyBuilder.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/HierarchyBuilder.cs
@@ -40,6 +40,10 @@ namespace Unity.Formats.USD {
       public bool isModel;
       public bool hasPayload;
       public UsdPrim prim;
+
+      // Provides a list of all bound skeletons under a UsdSkelRoot.
+      public UsdSkelBindingVector skelBindings;
+
       public SdfPath[] skelJoints;
       public string modelAssetPath;
       public string modelName;
@@ -53,6 +57,7 @@ namespace Unity.Formats.USD {
       {
       public static HierInfo[] result;
       public static Scene scene;
+      public static UsdSkelCache skelCache; // Thread safe.
       public static SdfPath[] paths;
 
       public void Run() {
@@ -73,7 +78,8 @@ namespace Unity.Formats.USD {
         info.isVisible = HierarchyBuilder.IsVisible(info.prim);
         info.isInstance = info.prim.IsInstance();
         HierarchyBuilder.ReadModelInfo(ref info);
-        HierarchyBuilder.ReadSkeleton(ref info);
+        HierarchyBuilder.PopulateSkelCache(ref info, ReadHierJob.skelCache);
+        HierarchyBuilder.ReadSkeletonJoints(ref info);
         info.hasPayload = info.prim.GetPrimIndex().HasAnyPayloads();
 
         result[index] = info;
@@ -117,7 +123,7 @@ namespace Unity.Formats.USD {
 #else
       void
 #endif
-      BeginReading(Scene scene,
+                       BeginReading(Scene scene,
                                     SdfPath usdRoot,
                                     PrimMap map,
                                     SceneImportOptions options) {
@@ -165,6 +171,7 @@ namespace Unity.Formats.USD {
       ReadHierJob.paths = FindPathsJob.results.Where(i => i != null).SelectMany(i => i).ToArray();
       ReadHierJob.result = new HierInfo[ReadHierJob.paths.Length];
       ReadHierJob.scene = scene;
+      ReadHierJob.skelCache = map.SkelCache;
       var readHierInfo = new ReadHierJob();
 #if !UNITY_2017
       return readHierInfo.Schedule(ReadHierJob.paths.Length, 8, dependsOn: findHandle);
@@ -179,6 +186,15 @@ namespace Unity.Formats.USD {
                                        SdfPath usdRoot,
                                        PrimMap map,
                                        SceneImportOptions options) {
+
+      if (map.SkelCache == null) {
+        // Note that UsdSkelCache is thread safe and can be populated from multiple threads.
+        map.SkelCache = new UsdSkelCache();
+
+        // The skelBindings dictionary, however, is not thread safe and must be populated after the
+        // hierarchy discovery thread joins, in ProcessPaths.
+        map.SkelBindings = new Dictionary<SdfPath, UsdSkelBindingVector>();
+      }
 
 #if !UNITY_2017
       BeginReading(scene, usdRoot, map, options).Complete();
@@ -271,7 +287,7 @@ namespace Unity.Formats.USD {
 
       if (options.importSkinning) {
         Profiler.BeginSample("Expand Skeletons");
-        foreach (var info in hierInfo) { 
+        foreach (var info in hierInfo) {
           if (info.skelJoints == null || info.skelJoints.Length == 0) {
             continue;
           }
@@ -380,6 +396,11 @@ namespace Unity.Formats.USD {
         var prim = info.prim;
         var path = info.prim.GetPath();
 
+        if (info.skelBindings != null) {
+          // Collect all discovered skelBindings back into the PrimMap.
+          map.SkelBindings.Add(info.prim.GetPath(), info.skelBindings);
+        }
+
         GameObject go;
         if (path == usdRoot) {
           go = unityRoot;
@@ -435,45 +456,76 @@ namespace Unity.Formats.USD {
       Profiler.EndSample();
     }
 
-    static void ReadSkeleton(ref HierInfo info) {
-      if (info.prim == null) { return; }
-
-      var skelRoot = new UsdSkelRoot(info.prim);
+    static void PopulateSkelCache(ref HierInfo skelRootInfo, UsdSkelCache skelCache) {
+      //
+      // Populate the UsdSkelCache.
+      //
+      var skelRoot = new UsdSkelRoot(skelRootInfo.prim);
       if (!skelRoot) { return; }
 
-      var skelRel = info.prim.GetRelationship(UsdSkelTokens.skelSkeleton);
-      if (!skelRel) { return; }
+      if (!skelCache.Populate(skelRoot)) {
+        Debug.LogWarning("Failed to populate skel cache: " + skelRootInfo.prim.GetPath());
+        return;
+      }
 
-      SdfPathVector targets = skelRel.GetForwardedTargets();
-      if (targets == null || targets.Count == 0) { return; }
-
-      var skelPrim = info.prim.GetStage().GetPrimAtPath(targets[0]);
-      if (!skelPrim) { return; }
-
-      var skel = new UsdSkelSkeleton(skelPrim);
-      if (!skel) { return; }
-
-      var jointsAttr = skel.GetJointsAttr();
-      if (!jointsAttr) { return; }
-
-      var vtJoints = jointsAttr.Get();
-      if (vtJoints.IsEmpty()) { return; }
-      var vtStrings = UsdCs.VtValueToVtTokenArray(vtJoints);
-      var joints = UnityTypeConverter.FromVtArray(vtStrings);
-
-      var skelPath = skelPrim.GetPath();
-      info.skelJoints = new SdfPath[joints.Length];
-
-      for (int i = 0; i < joints.Length; i++) {
-        var jointPath = new SdfPath(joints[i]);
-        if (joints[i] == "/") {
-          info.skelJoints[i] = skelPath;
-          continue;
-        } else if (jointPath.IsAbsolutePath()) {
-          Debug.LogException(new Exception("Unexpected absolute joint path: " + jointPath));
-          jointPath = new SdfPath(joints[i].TrimStart('/'));
+      try {
+        var binding = new UsdSkelBindingVector();
+        if (!skelCache.ComputeSkelBindings(skelRoot, binding)) {
+          Debug.LogWarning("ComputeSkelBindings failed: " + skelRootInfo.prim.GetPath());
+          return;
         }
-        info.skelJoints[i] = skelPath.AppendPath(jointPath);
+        skelRootInfo.skelBindings = binding;
+      } catch {
+        Debug.LogError("Failed to compute binding for SkelRoot: " + skelRootInfo.prim.GetPath());
+      }
+    }
+
+    /// <summary>
+    /// If HierInfo represents a UsdSkelRoot, reads the associated skelton joints into the
+    /// skelJoints member.
+    /// </summary>
+    static void ReadSkeletonJoints(ref HierInfo skelRootInfo) {
+      if (skelRootInfo.prim == null) { return; }
+
+      var skelRoot = new UsdSkelRoot(skelRootInfo.prim);
+      if (!skelRoot) { return; }
+
+      var processed = new HashSet<SdfPath>();
+      foreach (UsdSkelBinding binding in skelRootInfo.skelBindings) {
+        var skel = binding.GetSkeleton();
+
+        if (!skel) {
+          continue;
+        }
+
+        // If the same skeleton is referenced multiple times, only process it once.
+        if (processed.Contains(skel.GetPath())) {
+          continue;
+        }
+        processed.Add(skel.GetPath());
+
+        var jointsAttr = skel.GetJointsAttr();
+        if (!jointsAttr) { continue; }
+
+        var vtJoints = jointsAttr.Get();
+        if (vtJoints.IsEmpty()) { continue; }
+        var vtStrings = UsdCs.VtValueToVtTokenArray(vtJoints);
+        var joints = UnityTypeConverter.FromVtArray(vtStrings);
+
+        var skelPath = skel.GetPath();
+        skelRootInfo.skelJoints = new SdfPath[joints.Length];
+
+        for (int i = 0; i < joints.Length; i++) {
+          var jointPath = new SdfPath(joints[i]);
+          if (joints[i] == "/") {
+            skelRootInfo.skelJoints[i] = skelPath;
+            continue;
+          } else if (jointPath.IsAbsolutePath()) {
+            Debug.LogException(new Exception("Unexpected absolute joint path: " + jointPath));
+            jointPath = new SdfPath(joints[i].TrimStart('/'));
+          }
+          skelRootInfo.skelJoints[i] = skelPath.AppendPath(jointPath);
+        }
       }
     }
 

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImporter.cs
@@ -337,44 +337,8 @@ namespace Unity.Formats.USD {
       //
       // Pre-process UsdSkelRoots.
       //
+
       var skelRoots = new List<pxr.UsdSkelRoot>();
-
-      if (primMap.SkelCache == null) {
-        Profiler.BeginSample("USD: Populate SkelCache");
-        primMap.SkelBindings = new Dictionary<pxr.SdfPath, pxr.UsdSkelBindingVector>();
-        primMap.SkelCache = new pxr.UsdSkelCache();
-
-        foreach (var path in primMap.SkelRoots) {
-          var skelRootPrim = scene.GetPrimAtPath(path);
-          if (!skelRootPrim) {
-            Debug.LogWarning("SkelRoot prim not found: " + path);
-            continue;
-          }
-          var skelRoot = new pxr.UsdSkelRoot(skelRootPrim);
-          if (!skelRoot) {
-            Debug.LogWarning("SkelRoot prim not SkelRoot type: " + path);
-            continue;
-          }
-          if (!primMap.SkelCache.Populate(skelRoot)) {
-            Debug.LogWarning("Failed to populate skel cache: " + path);
-            continue;
-          }
-
-          try {
-            Profiler.BeginSample("Compute Skel Bindings");
-            var binding = new pxr.UsdSkelBindingVector();
-            if (!primMap.SkelCache.ComputeSkelBindings(skelRoot, binding)) {
-              Debug.LogWarning("ComputeSkelBindings failed");
-              continue;
-            }
-            primMap.SkelBindings.Add(path, binding);
-          } catch {
-            Debug.LogError("Failed to compute binding for SkelRoot: " + path);
-          }
-          Profiler.EndSample();
-        }
-      }
-
       if (importOptions.importSkinning) {
         Profiler.BeginSample("USD: Process UsdSkelRoots");
         foreach (var path in primMap.SkelRoots) {


### PR DESCRIPTION
Previously, the UsdSkelSkeleton relationship would only be queried on the SkelRoot prim. Now the search is extended to all children of the root as well.

I wanted to use the logic that is provided by the UsdSkelCache rather than implementing it myself, which meant the UsdSkelCache had to be populated sooner, which is the majority of complication in this change.

The UsdSkelCache is now populated as part of the multi-threaded hierarchy discovery phase, rather than populating it late in the SceneImporter.

Fixes #92.