### PR TITLE
Fix the ExportUsdz function to get every archive inner paths relative (FTV-172, #88)

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/UsdzExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/UsdzExporter.cs
@@ -15,45 +15,35 @@
 using System.IO;
 using UnityEngine;
 using USD.NET;
+using pxr;
 
 namespace Unity.Formats.USD {
   public class UsdzExporter {
 
     public static void ExportUsdz(string usdzFilePath,
                                   GameObject root) {
-      // Setup a temp directory for zipping up files.
-      string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-      var tmpUsdName = Path.GetFileNameWithoutExtension(usdzFilePath);
-      var di = Directory.CreateDirectory(tempDirectory);
-      var tmpUsdFilePath = Path.Combine(tempDirectory, tmpUsdName + ".usdc");
-      var curDir = Directory.GetCurrentDirectory();
+      // Keep the current directory to restore it at the end.
+      var currentDir = Directory.GetCurrentDirectory();
 
-      var supportedExtensions = new System.Collections.Generic.HashSet<string>();
-      supportedExtensions.Add(".usd");
-      supportedExtensions.Add(".usda");
-      supportedExtensions.Add(".usdc");
+      // Setup a temporary directory to export the wanted USD file and zip it.
+      string tmpDirPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+      DirectoryInfo tmpDir = Directory.CreateDirectory(tmpDirPath);
 
-      supportedExtensions.Add(".jpg");
-      supportedExtensions.Add(".jpeg");
-      supportedExtensions.Add(".jpe");
-      supportedExtensions.Add(".jif");
-      supportedExtensions.Add(".jfif");
-      supportedExtensions.Add(".jfi");
-
-      supportedExtensions.Add(".png");
-
-      // Create the temp .usd scene, into which the data will be exported.
-      var scene = InitForSave(tmpUsdFilePath);
-      var localScale = root.transform.localScale;
+      // Get the usd file name to export and the usdz file name of the archive.
+      string usdcFileName = Path.GetFileNameWithoutExtension(usdzFilePath) + ".usdc";
+      string usdzFileName = Path.GetFileName(usdzFilePath);
 
       try {
+        // Set the current working directory to the tmp directory to export with relative paths.
+        Directory.SetCurrentDirectory(tmpDirPath);
+
+        // Create the tmp .usd scene, into which the data will be exported.
+        Scene scene = InitForSave(usdcFileName);
+        Vector3 localScale = root.transform.localScale;
+
         try {
           // USDZ is in centimeters.
           root.transform.localScale = localScale * 100;
-
-          // Set the current working directory to the USDZ directory so the paths in USD
-          // will be relative.
-          Directory.SetCurrentDirectory(tempDirectory);
 
           // Export the temp scene.
           SceneExporter.Export(root,
@@ -72,38 +62,26 @@ namespace Unity.Formats.USD {
           scene = null;
         }
 
-        // Copy resulting files into the USDZ archive.
-        var filesToArchive = new pxr.StdStringVector();
+        SdfAssetPath assetPath = new SdfAssetPath(usdcFileName);
+        bool success = pxr.UsdCs.UsdUtilsCreateNewARKitUsdzPackage(assetPath, usdzFileName);
 
-        // According to the USDZ spec, the first file in the archive must be the primary USD file.
-        filesToArchive.Add(tmpUsdFilePath);
-
-        foreach (var fileInfo in di.GetFiles()) {
-          if (fileInfo.Name.ToLower() == Path.GetFileName(tmpUsdFilePath).ToLower()) {
-            continue;
-          }
-          var relPath = ImporterBase.MakeRelativePath(tmpUsdFilePath, fileInfo.FullName);
-          var ext = Path.GetExtension(relPath).ToLower();
-          if (!supportedExtensions.Contains(ext)) {
-            Debug.LogWarning("Unsupported file type in USDZ: " + relPath);
-            continue;
-          }
-          filesToArchive.Add(relPath);
+        if (!success) {
+          Debug.LogError("Couldn't export " + root.name + " to the usdz file: " + usdzFilePath);
         }
 
-        // Write the USDZ file.
-        pxr.UsdCs.WriteUsdZip(usdzFilePath, filesToArchive);
+        File.Copy(usdzFileName, usdzFilePath, overwrite: true);
+
       } finally {
         // Clean up temp files.
-        Directory.SetCurrentDirectory(curDir);
-        di.Delete(recursive: true);
+        Directory.SetCurrentDirectory(currentDir);
+        tmpDir.Delete(recursive: true);
       }
     }
 
     private static Scene InitForSave(string filePath) {
-      var fileDir = Path.GetDirectoryName(filePath);
+      string fileDir = Path.GetDirectoryName(filePath);
 
-      if (!Directory.Exists(fileDir)) {
+      if (!string.IsNullOrEmpty(fileDir) && !Directory.Exists(fileDir)) {
         var di = Directory.CreateDirectory(fileDir);
         if (!di.Exists) {
           Debug.LogError("Failed to create directory: " + fileDir);
@@ -112,7 +90,7 @@ namespace Unity.Formats.USD {
       }
 
       InitUsd.Initialize();
-      var scene = Scene.Create(filePath);
+      Scene scene = Scene.Create(filePath);
       scene.Time = 0;
       scene.StartTime = 0;
       scene.EndTime = 0;

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/UsdzExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/UsdzExporter.cs
@@ -67,6 +67,7 @@ namespace Unity.Formats.USD {
 
         if (!success) {
           Debug.LogError("Couldn't export " + root.name + " to the usdz file: " + usdzFilePath);
+          return;
         }
 
         File.Copy(usdzFileName, usdzFilePath, overwrite: true);


### PR DESCRIPTION
Use the native USD function: UsdUtilsCreateNewARKitUsdzPackage. This function find all the dependencies for us and archive everything together.

To ensure that all path were relative, the archive had to be created in the same folder were the source usd file and it's dependencies was. The archive is then copied to the destination folder provided.