### PR TITLE
Correctly handle metallic workflow

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/HdrpShaderImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/HdrpShaderImporter.cs
@@ -36,7 +36,7 @@ namespace Unity.Formats.USD {
 
       // TODO: What about opacity map?
       
-      if (IsMetallicWorkflow) {
+      if (!IsSpecularWorkflow) {
         // Robustness: It would be ideal if this parameter were provided by HDRP, however that
         // would require this asset package having a dependency on the HDRP package itself,
         // which is (yet) not desirable.
@@ -48,13 +48,13 @@ namespace Unity.Formats.USD {
       }
 
       // R=Metallic, G=Occlusion, B=Displacement, A=Roughness(Smoothness)
-      var MaskMap = BuildMaskMap(IsMetallicWorkflow ? MetallicMap : null, OcclusionMap, DisplacementMap, RoughnessMap);
+      var MaskMap = BuildMaskMap(!IsSpecularWorkflow ? MetallicMap : null, OcclusionMap, DisplacementMap, RoughnessMap);
       if (MaskMap) {
         mat.SetTexture("_MaskMap", MaskMap);
         mat.EnableKeyword("_MASKMAP");
       }
 
-      if (IsMetallicWorkflow) {
+      if (!IsSpecularWorkflow) {
         if (!MetallicMap) {
          mat.SetFloat("_Metallic", Metallic.GetValueOrDefault());
         }

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/ShaderImporterBase.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/ShaderImporterBase.cs
@@ -20,7 +20,7 @@ using USD.NET.Unity;
 namespace Unity.Formats.USD {
   public abstract class ShaderImporterBase {
     public Material Material { get; private set; }
-    public bool IsMetallicWorkflow { get; private set; }
+    public bool IsSpecularWorkflow { get; private set; }
 
     public Color? Diffuse;
     public Texture2D DiffuseMap;
@@ -106,6 +106,9 @@ namespace Unity.Formats.USD {
                                                 SceneImportOptions options) {
       var primvars = new List<string>();
       string uvPrimvar = null;
+
+      IsSpecularWorkflow = previewSurf.useSpecularWorkflow.defaultValue == 1;
+
       ImportColorOrMap(scene, previewSurf.diffuseColor, false, options, ref DiffuseMap, ref Diffuse, out uvPrimvar);
       MergePrimvars(uvPrimvar, primvars);
 
@@ -129,7 +132,7 @@ namespace Unity.Formats.USD {
 
       ClearcoatRoughness = previewSurf.clearcoatRoughness.defaultValue;
 
-      if (previewSurf.useSpecularWorkflow.defaultValue == 1) {
+      if (IsSpecularWorkflow) {
         ImportColorOrMap(scene, previewSurf.specularColor, false, options, ref SpecularMap, ref Specular, out uvPrimvar);
         MergePrimvars(uvPrimvar, primvars);
       } else {

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/StandardShaderImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/StandardShaderImporter.cs
@@ -61,7 +61,7 @@ namespace Unity.Formats.USD {
         }
       }
 
-      if (!IsMetallicWorkflow) {
+      if (IsSpecularWorkflow) {
         if (SpecularMap) {
           mat.SetTexture("_SpecGlossMap", SpecularMap);
           mat.EnableKeyword("_SPECGLOSSMAP");


### PR DESCRIPTION
Previously, the IsMetallicWorkflow flag was never set. The flag is now set correctly, which causes down-stream processing to work correctly now as well.

Renamed to IsSpecularWorkflow to closer match USD PreviewSurface (which is explicit about specular, not metallic).

Fixes #102