### PR TITLE
Resolve Skeleton/SkelRoot collision

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneExporter.cs
@@ -346,9 +346,18 @@ namespace Unity.Formats.USD {
             // The skeleton is exported at the skeleton root and UsdSkelAnimation is nested under
             // this prim as a new prim called "_anim".
             SkelRootSample rootSample = CreateSample<SkelRootSample>(context);
+            string skelRootPath = UnityTypeConverter.GetPath(animatorXf.transform, expRoot);
             string skelPath = UnityTypeConverter.GetPath(skeletonRoot, expRoot);
-            rootSample.skeleton = skelPath;
-            rootSample.animationSource = skelPath + "/_anim";
+            string skelPathSuffix = "";
+            string skelAnimSuffix = "/_anim";
+
+            if (skelPath == skelRootPath) {
+              Debug.LogWarning("SkelRoot and Skeleton have the same path, renaming Skeleton");
+              skelPathSuffix = "/_skel";
+            }
+
+            rootSample.skeleton = skelPath + skelPathSuffix;
+            rootSample.animationSource = skelPath + skelAnimSuffix;
 
             CreateExportPlan(
                 animatorXf.gameObject,
@@ -368,13 +377,15 @@ namespace Unity.Formats.USD {
                 CreateSample<SkeletonSample>(context),
                 SkeletonExporter.ExportSkeleton,
                 context,
-                insertFirst: true);
+                insertFirst: true,
+                pathSuffix: skelPathSuffix);
             CreateExportPlan(
                 skeletonRoot.gameObject,
                 CreateSample<SkeletonSample>(context),
                 NativeExporter.ExportObject,
                 context,
-                insertFirst: false);
+                insertFirst: false,
+                pathSuffix: skelPathSuffix);
 
             CreateExportPlan(
                 skeletonRoot.gameObject,
@@ -382,7 +393,7 @@ namespace Unity.Formats.USD {
                 SkeletonExporter.ExportSkelAnimation,
                 context,
                 insertFirst: true,
-                pathSuffix: "/_anim");
+                pathSuffix: skelAnimSuffix);
 
             // Exporting animation is only possible while in-editor (in 2018 and earlier).
 #if UNITY_EDITOR

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneExporter.cs
@@ -351,6 +351,13 @@ namespace Unity.Formats.USD {
             string skelPathSuffix = "";
             string skelAnimSuffix = "/_anim";
 
+            // When there is a collision between the SkelRoot and the Skeleton, make a new USD Prim
+            // for the Skeleton object. The reason this is safe is as follows: if the object was
+            // imported from USD, then the structure should already be correct and this code path will
+            // not be hit (and hence overrides, etc, will work correctly). If the object was created
+            // in Unity and there happened to be a collision, then we can safely create a new prim
+            // for the Skeleton prim because there will be no existing USD skeleton for which
+            // the namespace must match, hence adding a new prim is still safe.
             if (skelPath == skelRootPath) {
               Debug.LogWarning("SkelRoot and Skeleton have the same path, renaming Skeleton");
               skelPathSuffix = "/_skel";


### PR DESCRIPTION
When the Skeleton and SkelRoot share the same object, construct a new object in namespace for the skeleton. Previously, the UsdSkelRoot prim would be replaced with the UsdSkelSkeleton prim and the skeleton would no longer function.

Partial fix for #89