### PR TITLE
Samples: add proper asmdef to avoid build errors (FTV-191)

### DIFF
--- a/package/com.unity.formats.usd/Samples/ExportMesh/Unity.Formats.USD.ExportMesh.asmdef
+++ b/package/com.unity.formats.usd/Samples/ExportMesh/Unity.Formats.USD.ExportMesh.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "Unity.Formats.USD.ExportMesh",
+    "references": [
+        "Unity.Formats.USD.Runtime"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor",
+        "LinuxStandalone64",
+        "macOSStandalone",
+        "WindowsStandalone64"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "USD.NET.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/package/com.unity.formats.usd/Samples/HelloUsd/Unity.Formats.USD.HelloUsd.asmdef
+++ b/package/com.unity.formats.usd/Samples/HelloUsd/Unity.Formats.USD.HelloUsd.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "Unity.Formats.USD.HelloUsd",
+    "references": [
+        "Unity.Formats.USD.Runtime"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor",
+        "LinuxStandalone64",
+        "macOSStandalone",
+        "WindowsStandalone64"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "USD.NET.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/package/com.unity.formats.usd/Samples/ImportMaterials/Unity.Formats.USD.ImportMaterials.asmdef
+++ b/package/com.unity.formats.usd/Samples/ImportMaterials/Unity.Formats.USD.ImportMaterials.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "Unity.Formats.USD.ImportMaterials",
+    "references": [
+        "Unity.Formats.USD.Runtime"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor",
+        "LinuxStandalone64",
+        "macOSStandalone",
+        "WindowsStandalone64"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "USD.NET.dll",
+        "USD.NET.Unity.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/package/com.unity.formats.usd/Samples/ImportMesh/Unity.Formats.USD.ImportMesh.asmdef
+++ b/package/com.unity.formats.usd/Samples/ImportMesh/Unity.Formats.USD.ImportMesh.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "Unity.Formats.USD.ImportMesh",
+    "references": [
+        "Unity.Formats.USD.Runtime"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor",
+        "LinuxStandalone64",
+        "macOSStandalone",
+        "WindowsStandalone64"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "USD.NET.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/package/com.unity.formats.usd/Samples/ImportProcessor/Unity.Formats.USD.ImportProcessor.asmdef
+++ b/package/com.unity.formats.usd/Samples/ImportProcessor/Unity.Formats.USD.ImportProcessor.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "Unity.Formats.USD.ImportProcessor",
+    "references": [
+        "Unity.Formats.USD.Runtime"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor",
+        "LinuxStandalone64",
+        "macOSStandalone",
+        "WindowsStandalone64"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "USD.NET.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": []
+}


### PR DESCRIPTION
When importing some samples, build could fail because of missing definitions.
Fix consisted into adding asmdef files that reference the precompiled libs (USD.Net).