### PR TITLE
Initialize USD before changing CWD

### DIFF
--- a/package/com.unity.formats.usd/Runtime/InitUsd.cs
+++ b/package/com.unity.formats.usd/Runtime/InitUsd.cs
@@ -51,6 +51,8 @@ namespace Unity.Formats.USD {
     private static void SetupUsdPath()
     {
 #if UNITY_EDITOR
+      // TODO: this is not robust, e.g. if anyone changes CWD from the default, package resolution
+      // will fail. Following up with UPM devs to see what we can do about it.
       var supPath = System.IO.Path.GetFullPath("Packages/com.unity.formats.usd/Runtime/Plugins");
 #else
       var supPath = UnityEngine.Application.dataPath.Replace("\\", "/") + "/Plugins";

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/UsdzExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/UsdzExporter.cs
@@ -22,6 +22,11 @@ namespace Unity.Formats.USD {
 
     public static void ExportUsdz(string usdzFilePath,
                                   GameObject root) {
+      // Ensure USD is initialized before changing CWD.
+      // This does not protect us against external changes to CWD, so we are actively looking for
+      // a more robust solution with UPM devs.
+      InitUsd.Initialize();
+
       // Keep the current directory to restore it at the end.
       var currentDir = Directory.GetCurrentDirectory();
 


### PR DESCRIPTION
Previously, if the USD libs were initialized AFTER the current working directory was changed for USDZ export. This is no ta problem unless you happen to export USDZ as the first USD operation in the Unity process, then USD initialization will fail because the package resolution relies on a relative path starting with "packages/...". While this is the recommended way to resolve package paths via the UPM docs, it is not robust against changes to the current directory.

As a workaround, this change initializes USD before changing the working directory, however it is still not protected against third party changes to CWD. Following up with packman devs on a more robust approach.

In the worst case, we can attempt to initialize USD as soon as the editor launches, or at least capture the CWD at that point for use with initialization.