### PR TITLE
Also check the current GameObject for UsdAsset

### DIFF
--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdPrimSourceEditor.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdPrimSourceEditor.cs
@@ -31,6 +31,10 @@ namespace Unity.Formats.USD {
       var stageRoot = attachment.GetComponentInParent<UsdAsset>();
 
       if (!stageRoot) {
+        stageRoot = attachment.GetComponent<UsdAsset>();
+      }
+
+      if (!stageRoot) {
         Debug.LogError("No stage root found");
         return;
       }


### PR DESCRIPTION
This is required now that the root UsdAsset GameObject can also have valid USD components added to it (previously, only children of the UsdAsset could, which meant GetcomponentInParent was always correct, now we much check the current GameObject in addition).