### PR TITLE
Correctly export mesh & skeleton bounding box

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
@@ -193,7 +193,7 @@ namespace Unity.Formats.USD {
       // Only export the mesh topology on the first frame.
       if (unvarying) {
         // TODO: Technically a mesh could be the root transform, which is not handled correctly here.
-        // It should ahve the same logic for root prims as in ExportXform.
+        // It should have the same logic for root prims as in ExportXform.
         sample.transform = XformExporter.GetLocalTransformMatrix(
             go.transform,
             scene.UpAxis == Scene.UpAxes.Z,

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
@@ -430,7 +430,6 @@ namespace Unity.Formats.USD {
         Profiler.BeginSample("Import Bounds");
         if (changeHandedness) {
           usdMesh.extent.center = UnityTypeConverter.ChangeBasis(usdMesh.extent.center);
-          usdMesh.extent.extents = UnityTypeConverter.ChangeBasis(usdMesh.extent.extents);
         }
         unityMesh.bounds = usdMesh.extent;
         Profiler.EndSample();

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Skel/SkeletonExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Skel/SkeletonExporter.cs
@@ -83,26 +83,30 @@ namespace Unity.Formats.USD {
 
       // Compute bounds for the root, required by USD.
       bool first = true;
-      foreach (var r in objContext.gameObject.GetComponentsInChildren<Renderer>()) {
-        if (first) {
-          // Ensure the bounds object starts growing from the first valid child bounds.
-          first = false;
-          sample.extent = r.bounds;
-        } else {
-          sample.extent.Encapsulate(r.bounds);
+
+      // Ensure the bounds are computed in root-local space.
+      // This is required because USD expects the extent to be a local bound for the SkelRoot.
+      var oldParent = objContext.gameObject.transform.parent;
+      objContext.gameObject.transform.SetParent(null, worldPositionStays: false);
+
+      try {
+        foreach (var r in objContext.gameObject.GetComponentsInChildren<Renderer>()) {
+          if (first) {
+            // Ensure the bounds object starts growing from the first valid child bounds.
+            first = false;
+            sample.extent = r.bounds;
+          } else {
+            sample.extent.Encapsulate(r.bounds);
+          }
         }
+      } finally {
+        // Restore the root parent.
+        objContext.gameObject.transform.SetParent(oldParent, worldPositionStays: false);
       }
 
-
-      // Convert the bounds from worldspace to local space.
-      // This is required because USD expects the extent to be a local bound for the SkelRoot.
-      var xf = objContext.gameObject.transform;
-      sample.extent.min = xf.worldToLocalMatrix.MultiplyPoint(sample.extent.min);
-      sample.extent.max = xf.worldToLocalMatrix.MultiplyPoint(sample.extent.max);
-
+      // Convert handedness if needed.
       if (exportContext.basisTransform == BasisTransformation.SlowAndSafe) {
-        sample.extent.min = UnityTypeConverter.ChangeBasis(sample.extent.min);
-        sample.extent.max = UnityTypeConverter.ChangeBasis(sample.extent.max);
+        sample.extent.center = UnityTypeConverter.ChangeBasis(sample.extent.center);
       }
 
       exportContext.scene.Write(objContext.path, sample);


### PR DESCRIPTION
Import: Previously, both the center and extent of imported objects were converted, which generated incorrect bounding boxes (too large). While this was not immediately visible in Unity, when exporting an imported USD object, the exported bounds would be too large. This can be verified by forcing the importer to compute the BBox instead of reading it from USD, then export the imported object (the exported box that is computed is correct, the exported bbox that was originally imported from USD is incorrect).

Export: Previously the SkelRoot bounds was computed in world space with a correction to convert from worldspace to local space. However, this transform was not correct. Rather than trying to fix the transform after accumulation, the accumulation is now preformed in local space by temporarily setting the SkelRoot parent to null.

Fixes #81 