### PR TITLE
UsdSkel: Bind skeleton at mesh, not root

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
@@ -48,24 +48,33 @@ namespace Unity.Formats.USD {
       }
 
       UnityEngine.Profiling.Profiler.BeginSample("USD: Skinning Weights");
+
+      // Skeleton path is stored in additionalData via the SceneExporter SyncExportContext(). It
+      // would be nice to formalize this, rather than passing it as blind data.
+      var skeletonPath = (string)objContext.additionalData;
+
       ExportSkelWeights(exportContext.scene,
                         objContext.path,
                         smr.sharedMesh,
                         rootBone,
-                        smr.bones);
+                        smr.bones,
+                        skeletonPath);
       UnityEngine.Profiling.Profiler.EndSample();
-
     }
 
     static void ExportSkelWeights(Scene scene,
                                   string path,
                                   Mesh unityMesh,
                                   Transform rootBone,
-                                  Transform[] bones) {
+                                  Transform[] bones,
+                                  string skeletonPath) {
       var sample = new SkelBindingSample();
 
       sample.geomBindTransform.value = Matrix4x4.identity;
       sample.joints = new string[bones.Length];
+      if (!string.IsNullOrEmpty(skeletonPath)) {
+        sample.skeleton.targetPaths = new string[] { skeletonPath };
+      }
 
       int b = 0;
       var rootPath = UnityTypeConverter.GetPath(rootBone);

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Skel/SkeletonExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Skel/SkeletonExporter.cs
@@ -72,14 +72,6 @@ namespace Unity.Formats.USD {
 
     public static void ExportSkelRoot(ObjectContext objContext, ExportContext exportContext) {
       var sample = (SkelRootSample)objContext.sample;
-      var bindings = ((string[])objContext.additionalData);
-
-      if (bindings != null) {
-        sample.skeleton = bindings[0];
-        if (bindings.Length > 1) {
-          sample.animationSource = bindings[1];
-        }
-      }
 
       // Compute bounds for the root, required by USD.
       bool first = true;


### PR DESCRIPTION
Previously the UsdSkel skeleton was bound once at the root and this binding was inherited down namespace to every mesh below it. This did not work well with AR Quick Look (the binding was not respected) and it occasionally introduced issues with mesh bindings in the joint hierarchy.

With this change, now each mesh is bound to the skeleton individually. To do this, the binding must be set after the UsdSkelRoot is discovered, which introduced a slightly awkward bit of logic in the exporter. It would be nice to clean this up in the future.