### PR TITLE
Include mesh tangents in basis conversion on export

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
@@ -239,6 +239,11 @@ namespace Unity.Formats.USD {
             if (sample.normals != null && sample.normals.Length == sample.points.Length) {
               sample.normals[i] = UnityTypeConverter.ChangeBasis(sample.normals[i]);
             }
+			if (sample.tangents != null && sample.tangents.Length == sample.points.Length) {
+              var w = sample.tangents[i].w;
+              var t = UnityTypeConverter.ChangeBasis(sample.tangents[i]);
+              sample.tangents[i] = new Vector4(t.x, t.y, t.z, w);
+            }
           }
 
           for (int i = 0; i < tris.Length; i += 3) {

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
@@ -239,7 +239,7 @@ namespace Unity.Formats.USD {
             if (sample.normals != null && sample.normals.Length == sample.points.Length) {
               sample.normals[i] = UnityTypeConverter.ChangeBasis(sample.normals[i]);
             }
-			if (sample.tangents != null && sample.tangents.Length == sample.points.Length) {
+            if (sample.tangents != null && sample.tangents.Length == sample.points.Length) {
               var w = sample.tangents[i].w;
               var t = UnityTypeConverter.ChangeBasis(sample.tangents[i]);
               sample.tangents[i] = new Vector4(t.x, t.y, t.z, w);


### PR DESCRIPTION
I noticed my normal maps were rendering incorrectly when doing a round trip from Unity > USD > Unity. I eventually narrowed it down to MeshExporter.cs not converting the basis for mesh tangents when using slow and safe transformation. I copied the basis transformation process used to convert the tangents on import into the export step where the vertices and normals are transformed. Now, tangents seem to export correctly and normal maps seem to render correctly. Attached is a screenshot demonstrating the difference with a shader that draws the mesh's tangents as color - left is the original model, middle is the model round-tripped with the fix and right is the model round-tripped without the fix.
![Unity_mX8M1tTrvR](https://user-images.githubusercontent.com/53349897/61973146-66c88400-afb1-11e9-8eaa-28d793019a06.png)