### PR TITLE
MeshExporter mesh readable fix in editor

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
@@ -154,24 +154,24 @@ namespace Unity.Formats.USD {
         // This is a workaround for a Unity peculiarity - 
         // non-readable meshes are actually always accessible from the Editor.
         // We're still logging a warning since this won't work in a build.
-        static bool CanReadMesh(Mesh mesh)
-        {
-            if (mesh.isReadable) return true;
-            if (!Application.isPlaying) return true;
-
-            if (Mesh_canAccess == null)
+        static bool CanReadMesh(Mesh mesh) {
+            if (mesh.isReadable) {
+                return true;
+            }
+            if (!Application.isPlaying) {
+                return true;
+            }
+            if (Mesh_canAccess == null) {
                 Mesh_canAccess = typeof(Mesh).GetProperty("canAccess", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetMethod;
-
-            if(Mesh_canAccess != null)
-            {
+            }
+            if(Mesh_canAccess != null) {
                 try {
                     bool canAccess = (bool) Mesh_canAccess.Invoke(mesh, null);
                     if(canAccess) {
                         Debug.LogWarning("The mesh you are trying to export is not marked as readable. This will only work in the Editor and fail in a Build.", mesh);
                         return true;
                     }
-                }
-                catch { 
+                } catch { 
                     // There has probably been an Unity internal API update causing an error on this call.
                     return false;
                 }
@@ -209,11 +209,10 @@ namespace Unity.Formats.USD {
       }
 
 #if UNITY_EDITOR
-      if (!CanReadMesh(mesh))
+      if (!CanReadMesh(mesh)) {
 #else
-      if(!mesh.isReadable)
+      if(!mesh.isReadable) {
 #endif
-      {
         Debug.LogError("Mesh is not readable: " + objContext.path  + ". To fix this, enable read/write in the inspector for the source asset that you are attempting to export.", objContext.gameObject);
         return;
       }

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
@@ -176,8 +176,8 @@ namespace Unity.Formats.USD {
         Debug.LogWarning("Null mesh for: " + path);
         return;
       }
-      if (mesh.isReadable == false) {
-        Debug.LogWarning("Mesh not readable: " + objContext.path);
+      if (mesh.isReadable == false && !Application.isEditor) {
+        Debug.LogError("Mesh not readable: " + objContext.path);
         return;
       }
 


### PR DESCRIPTION
Meshes in editor are always readable, no need to return. Also, changed Log from warning to error as this actually corrupts data when it fails