### PR TITLE
Better handling of non-matching submesh indices + materials

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
@@ -315,8 +315,11 @@ namespace Unity.Formats.USD {
                 );
 
             if (exportContext.exportMaterials) {
-              if (si >= sharedMaterials.Length || !exportContext.matMap.TryGetValue(sharedMaterials[si], out usdMaterialPath)) {
-                Debug.LogError("Invalid material bound for: " + path);
+              if (si >= sharedMaterials.Length || !sharedMaterials[si] || !exportContext.matMap.TryGetValue(sharedMaterials[si], out usdMaterialPath)) {
+                Debug.LogWarning("Invalid material bound for: " + path + "\n" 
+                    + (si >= sharedMaterials.Length ? "More submeshes than materials assigned."
+                    : (!sharedMaterials[si] ? "Submesh " + si + " has null material"
+                    : "ExportMap can't map material")));
               } else {
                 MaterialSample.Bind(scene, subset.GetPath(), usdMaterialPath);
               }


### PR DESCRIPTION
Check that materials are not null, change LogError to LogWarning (this is not corrupting data).
Also, better logs for what went wrong