### PR TITLE
FTV-244 prefab reset on play mode

### DIFF
--- a/TestProject/Packages/manifest.json
+++ b/TestProject/Packages/manifest.json
@@ -1,12 +1,9 @@
 {
   "dependencies": {
-    "com.unity.ads": "2.0.8",
-    "com.unity.analytics": "3.2.2",
-    "com.unity.collab-proxy": "1.2.15",
+    "com.unity.analytics": "3.3.5",
+    "com.unity.ext.nunit": "1.0.0",
     "com.unity.formats.usd": "file:../../package/com.unity.formats.usd/",
-    "com.unity.package-manager-ui": "2.0.3",
-    "com.unity.purchasing": "2.0.3",
-    "com.unity.textmeshpro": "1.3.0",
+    "com.unity.test-framework": "1.1.11",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",
@@ -38,8 +35,7 @@
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
   },
-  "testables": 
-  [
+  "testables": [
     "com.unity.formats.usd"
   ]
 }

--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
@@ -211,13 +211,6 @@ namespace Unity.Formats.USD {
 
 #if UNITY_EDITOR
     /// <summary>
-    /// Used to track when a UsdAsset is duplicated. When duplicated, the meshes and materials
-    /// need to be instanced to keep the duplicated object from sharing the underlying assets.
-    /// </summary>
-    [SerializeField, HideInInspector]
-    private int m_instanceId = 0;
-
-    /// <summary>
     /// Returns the underlying prefab object, or null.
     /// </summary>
     private GameObject GetPrefabObject(GameObject root) {
@@ -228,26 +221,6 @@ namespace Unity.Formats.USD {
       // https://github.com/Unity-Technologies/UniteLA2018Examples/blob/master/Assets/Scripts/GameObjectTypeLogging.cs
       return UnityEditor.PrefabUtility.GetCorrespondingObjectFromSource(root);
 #endif
-    }
-
-    private bool IsPrefabInstance(GameObject root) {
-      return GetPrefabObject(root) != null;
-    }
-
-    void Awake() {
-      if (IsPrefabInstance(gameObject)) { return; }
-
-      if (m_instanceId != GetInstanceID()) {
-        if (m_instanceId == 0) {
-          m_instanceId = GetInstanceID();
-        } else {
-          m_instanceId = GetInstanceID();
-          if (m_instanceId < 0) {
-            Debug.Log("Reimporting " + name + " after duplicate");
-            Reload(true);
-          }
-        }
-      }
     }
 #endif
 

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
@@ -225,7 +225,7 @@ namespace Unity.Formats.USD {
                              SceneImportOptions options) {
       var smr = ImporterBase.GetOrAddComponent<SkinnedMeshRenderer>(go);
       if (smr.sharedMesh == null) {
-        smr.sharedMesh = new Mesh();
+        smr.sharedMesh = new Mesh {name = Guid.NewGuid().ToString()};
       }
 
       BuildMesh_(path, usdMesh, smr.sharedMesh, geomSubsets, go, smr, options);
@@ -241,8 +241,10 @@ namespace Unity.Formats.USD {
                              SceneImportOptions options) {
       var mf = ImporterBase.GetOrAddComponent<MeshFilter>(go);
       var mr = ImporterBase.GetOrAddComponent<MeshRenderer>(go);
-      if (mf.sharedMesh == null) {
-        mf.sharedMesh = new Mesh();
+      if (mf.sharedMesh == null)
+      {
+        mf.sharedMesh = new Mesh {name = Guid.NewGuid().ToString()};
+        mf.sharedMesh.MarkDynamic();
       }
 
       BuildMesh_(path, usdMesh, mf.sharedMesh, geomSubsets, go, mr, options);


### PR DESCRIPTION
Remove the "rebuildAll on clone" logic and add guid as mesh names. (FTV-244)

We used to force a rebuild of the hierarchy when a UsdAsset (game object)
was duplicated to avoid sharing meshes and materials.
This caused an issue when game objects created from usd prefabs in
PlayMode where flagged for rebuild, losing all local edits.

I decided to remove the "rebuildAll on clone" logic and keep meshes and
materials shared between copies of UsdAsset imported as game objects.
That's the behavior I expect when I duplicate a usd asset reading the same
location in a usd file. It's also safe to do for skinned meshes as skinning is applied
in a vertex shader and the underlying shared mesh is not deformed.

The only drawback is that it won't work on deformed meshes in the case
you change playback speed between the copies. But the solution is simple,
you just have to reload and rebuild the hierachy in the UsdAsset.

I also set the name of the meshes with a guid to make it obvious that
the meshes are shared.