### PR TITLE
Remove the "rebuildAll on clone" logic and add guid as mesh names. (F…

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
@@ -211,13 +211,6 @@ namespace Unity.Formats.USD {
 
 #if UNITY_EDITOR
     /// <summary>
-    /// Used to track when a UsdAsset is duplicated. When duplicated, the meshes and materials
-    /// need to be instanced to keep the duplicated object from sharing the underlying assets.
-    /// </summary>
-    [SerializeField, HideInInspector]
-    private int m_instanceId = 0;
-
-    /// <summary>
     /// Returns the underlying prefab object, or null.
     /// </summary>
     private GameObject GetPrefabObject(GameObject root) {
@@ -228,26 +221,6 @@ namespace Unity.Formats.USD {
       // https://github.com/Unity-Technologies/UniteLA2018Examples/blob/master/Assets/Scripts/GameObjectTypeLogging.cs
       return UnityEditor.PrefabUtility.GetCorrespondingObjectFromSource(root);
 #endif
-    }
-
-    private bool IsPrefabInstance(GameObject root) {
-      return GetPrefabObject(root) != null;
-    }
-
-    void Awake() {
-      if (IsPrefabInstance(gameObject)) { return; }
-
-      if (m_instanceId != GetInstanceID()) {
-        if (m_instanceId == 0) {
-          m_instanceId = GetInstanceID();
-        } else {
-          m_instanceId = GetInstanceID();
-          if (m_instanceId < 0) {
-            Debug.Log("Reimporting " + name + " after duplicate");
-            Reload(true);
-          }
-        }
-      }
     }
 #endif
 

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
@@ -225,7 +225,7 @@ namespace Unity.Formats.USD {
                              SceneImportOptions options) {
       var smr = ImporterBase.GetOrAddComponent<SkinnedMeshRenderer>(go);
       if (smr.sharedMesh == null) {
-        smr.sharedMesh = new Mesh {name = Guid.NewGuid().ToString()};
+        smr.sharedMesh = new Mesh {name = UniqueMeshName(go.name)};
       }
 
       BuildMesh_(path, usdMesh, smr.sharedMesh, geomSubsets, go, smr, options);
@@ -241,10 +241,8 @@ namespace Unity.Formats.USD {
                              SceneImportOptions options) {
       var mf = ImporterBase.GetOrAddComponent<MeshFilter>(go);
       var mr = ImporterBase.GetOrAddComponent<MeshRenderer>(go);
-      if (mf.sharedMesh == null)
-      {
-        mf.sharedMesh = new Mesh {name = Guid.NewGuid().ToString()};
-        mf.sharedMesh.MarkDynamic();
+      if (mf.sharedMesh == null) {
+        mf.sharedMesh = new Mesh {name = UniqueMeshName(go.name)};
       }
 
       BuildMesh_(path, usdMesh, mf.sharedMesh, geomSubsets, go, mr, options);
@@ -850,6 +848,14 @@ namespace Unity.Formats.USD {
     /// </summary>
     private static bool ShouldCompute(ImportMode mode) {
       return mode == ImportMode.Compute || mode == ImportMode.ImportOrCompute;
+    }
+
+    /// <summary>
+    /// Returns a unique mesh name by appending a short guid to the given string 
+    /// </summary>
+    private static string UniqueMeshName(string meshName) {
+      var shortGuid = Convert.ToBase64String(Guid.NewGuid().ToByteArray());
+      return meshName + "_" +  shortGuid.Substring(0, shortGuid.Length-2); 
     }
   }
 }

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
@@ -225,7 +225,7 @@ namespace Unity.Formats.USD {
                              SceneImportOptions options) {
       var smr = ImporterBase.GetOrAddComponent<SkinnedMeshRenderer>(go);
       if (smr.sharedMesh == null) {
-        smr.sharedMesh = new Mesh();
+        smr.sharedMesh = new Mesh {name = Guid.NewGuid().ToString()};
       }
 
       BuildMesh_(path, usdMesh, smr.sharedMesh, geomSubsets, go, smr, options);
@@ -241,8 +241,10 @@ namespace Unity.Formats.USD {
                              SceneImportOptions options) {
       var mf = ImporterBase.GetOrAddComponent<MeshFilter>(go);
       var mr = ImporterBase.GetOrAddComponent<MeshRenderer>(go);
-      if (mf.sharedMesh == null) {
-        mf.sharedMesh = new Mesh();
+      if (mf.sharedMesh == null)
+      {
+        mf.sharedMesh = new Mesh {name = Guid.NewGuid().ToString()};
+        mf.sharedMesh.MarkDynamic();
       }
 
       BuildMesh_(path, usdMesh, mf.sharedMesh, geomSubsets, go, mr, options);

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
@@ -34,7 +34,8 @@ namespace Unity.Formats.USD {
                                              T sample,
                                              MeshImporter.GeometrySubsets subsets,
                                              GameObject go,
-                                             SceneImportOptions option) where T : SampleBase, new();
+                                             SceneImportOptions option,
+                                             bool isDynamic) where T : SampleBase, new();
 
   /// <summary>
   /// This class is responsible for importing mesh samples into Unity. By swapping out the
@@ -71,6 +72,7 @@ namespace Unity.Formats.USD {
       System.Reflection.MemberInfo orientation = null;
       System.Reflection.MemberInfo purpose = null;
       System.Reflection.MemberInfo visibility = null;
+      bool isDynamic = false;
 
       if (scene.AccessMask != null && scene.IsPopulatingAccessMask) {
         var meshType = typeof(MeshSample);
@@ -100,6 +102,8 @@ namespace Unity.Formats.USD {
             if (pathAndSample.sample.visibility != Visibility.Inherited && !members.Contains(visibility)) {
               members.Add(visibility);
             }
+
+            isDynamic = true;
           }
         }
 
@@ -143,13 +147,13 @@ namespace Unity.Formats.USD {
             Profiler.BeginSample("USD: Build Skinned Mesh");
             m_skinnedMeshImporter(pathAndSample.path,
                                   pathAndSample.sample,
-                                  subsets, go, importOptions);
+                                  subsets, go, importOptions, isDynamic);
             Profiler.EndSample();
           } else {
             Profiler.BeginSample("USD: Build Mesh");
             m_meshImporter(pathAndSample.path,
                            pathAndSample.sample,
-                           subsets, go, importOptions);
+                           subsets, go, importOptions, isDynamic);
             Profiler.EndSample();
           }
         } catch (Exception ex) {
@@ -222,10 +226,17 @@ namespace Unity.Formats.USD {
                              MeshSample usdMesh,
                              GeometrySubsets geomSubsets,
                              GameObject go,
-                             SceneImportOptions options) {
+                             SceneImportOptions options,
+                             bool isDynamic) {
       var smr = ImporterBase.GetOrAddComponent<SkinnedMeshRenderer>(go);
       if (smr.sharedMesh == null) {
         smr.sharedMesh = new Mesh {name = UniqueMeshName(go.name)};
+      }
+            
+      // We only check if a mesh is dynamic when scene.IsPopulatingAccessMask is True. It only happens when a playable is
+      // created, potentially way after mesh creation.
+      if (isDynamic) {
+        smr.sharedMesh.MarkDynamic();
       }
 
       BuildMesh_(path, usdMesh, smr.sharedMesh, geomSubsets, go, smr, options);
@@ -238,11 +249,18 @@ namespace Unity.Formats.USD {
                              MeshSample usdMesh,
                              GeometrySubsets geomSubsets,
                              GameObject go,
-                             SceneImportOptions options) {
+                             SceneImportOptions options,
+                             bool isDynamic) {
       var mf = ImporterBase.GetOrAddComponent<MeshFilter>(go);
       var mr = ImporterBase.GetOrAddComponent<MeshRenderer>(go);
       if (mf.sharedMesh == null) {
         mf.sharedMesh = new Mesh {name = UniqueMeshName(go.name)};
+      }
+      
+      // We only check if a mesh is dynamic when scene.IsPopulatingAccessMask is True. It only happens when a playable is
+      // created, potentially way after mesh creation.
+      if (isDynamic) {
+        mf.sharedMesh.MarkDynamic();
       }
 
       BuildMesh_(path, usdMesh, mf.sharedMesh, geomSubsets, go, mr, options);

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImporter.cs
@@ -651,7 +651,8 @@ namespace Unity.Formats.USD {
                 NativeImporter.ImportObject(scene, go, scene.GetPrimAtPath(pathAndSample.path), importOptions);
                 XformImporter.BuildXform(pathAndSample.path, pathAndSample.sample, go, importOptions, scene);
                 var subsets = MeshImporter.ReadGeomSubsets(scene, pathAndSample.path);
-                MeshImporter.BuildMesh(pathAndSample.path, pathAndSample.sample, subsets, go, importOptions);
+                MeshImporter.BuildMesh(pathAndSample.path, pathAndSample.sample, subsets, go, importOptions, 
+                             scene.AccessMask.Included.ContainsKey(pathAndSample.path));
               } catch (System.Exception ex) {
                 Debug.LogException(
                     new ImportException("Error processing mesh <" + pathAndSample.path + ">", ex));


### PR DESCRIPTION
…TV-244)

We used to force a rebuild of the hierarchy when a UsdAsset (game object)
was duplicated to avoid sharing meshes and materials.
This caused an issue when game objects created from usd prefabs in
PlayMode where flagged for rebuild, losing all local edits.

I decided to remove the "rebuildAll on clone" logic and keep meshes and
materials shared between copies of UsdAsset imported as game objects.
That's the behavior I expect when I duplicate a usd asset reading the same
location in a usd file. It's also safe to do for skinned meshes as skinning is applied
in a vertex shader and the underlying shared mesh is not deformed.

The only drawback is that it won't work on deformed meshes in the case
you change playback speed between the copies. But the solution is simple,
you just have to reload and rebuild the hierachy in the UsdAsset.

I also set the name of the meshes with a guid to make it obvious that
the meshes are shared.