### PR TITLE
Export textures from packages

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/ShaderExporterBase.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/ShaderExporterBase.cs
@@ -36,8 +36,9 @@ namespace Unity.Formats.USD {
                                  string textureOutput) {
 #if UNITY_EDITOR
       var srcPath = UnityEditor.AssetDatabase.GetAssetPath(material.GetTexture(textureName));
-      srcPath = srcPath.Substring("Assets/".Length);
-      srcPath = Application.dataPath + "/" + srcPath;
+      var dataPath = Application.dataPath;
+      dataPath = dataPath.Substring(0, dataPath.LastIndexOf("Assets"));
+      srcPath = dataPath + srcPath;
       var fileName = System.IO.Path.GetFileName(srcPath);
       var filePath = System.IO.Path.Combine(destTexturePath, fileName);
 


### PR DESCRIPTION
As we move more and more of our code and data into packages, assets (including textures) are also in packages. This PR fixes USD / USDZ texture export pathes for that case.