### PR TITLE
USDZ timeline export in UsdRecorderClip

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneExporter.cs
@@ -56,6 +56,7 @@ namespace Unity.Formats.USD {
     public Transform exportRoot;
     public bool exportMaterials = true;
     public bool exportNative = false;
+    public float scale = 1.0f;
 
     public BasisTransformation basisTransform = BasisTransformation.FastWithNegativeScale;
     public ActiveExportPolicy activePolicy = ActiveExportPolicy.ExportAsVisibility;
@@ -152,6 +153,8 @@ namespace Unity.Formats.USD {
         root.transform.localRotation = Quaternion.identity;
         root.transform.localScale = Vector3.one;
       }
+      // Scale overall scene for export (e.g. USDZ export needs scale 100)
+      root.transform.localScale *= context.scale;
 
       UnityEngine.Profiling.Profiler.BeginSample("USD: Export");
       try {
@@ -167,6 +170,9 @@ namespace Unity.Formats.USD {
           root.transform.localRotation = localRot;
           root.transform.localScale = localScale;
           root.transform.SetParent(parent, worldPositionStays: false);
+        }
+        else {
+          root.transform.localScale = localScale;
         }
         UnityEngine.Profiling.Profiler.EndSample();
       }

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/UsdzExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/UsdzExporter.cs
@@ -84,7 +84,7 @@ namespace Unity.Formats.USD {
       }
     }
 
-    private static Scene InitForSave(string filePath) {
+    public static Scene InitForSave(string filePath) {
       string fileDir = Path.GetDirectoryName(filePath);
 
       if (!string.IsNullOrEmpty(fileDir) && !Directory.Exists(fileDir)) {

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/UsdzExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/UsdzExporter.cs
@@ -84,7 +84,7 @@ namespace Unity.Formats.USD {
       }
     }
 
-    public static Scene InitForSave(string filePath) {
+    internal static Scene InitForSave(string filePath) {
       string fileDir = Path.GetDirectoryName(filePath);
 
       if (!string.IsNullOrEmpty(fileDir) && !Directory.Exists(fileDir)) {

--- a/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
@@ -15,6 +15,8 @@
 using UnityEngine;
 using UnityEngine.Playables;
 using USD.NET;
+using System.IO;
+using pxr;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -25,6 +27,12 @@ namespace Unity.Formats.USD {
 
     bool m_isPaused = false;
     public UsdRecorderClip Clip;
+    string usdcFileName;
+    string usdzFileName;
+    string usdzFilePath;
+    string currentDir;
+    DirectoryInfo tmpDir;
+    GameObject _root;
 
     // ------------------------------------------------------------------------------------------ //
     // Recording Control.
@@ -32,6 +40,7 @@ namespace Unity.Formats.USD {
 
     public void BeginRecording(double currentTime, GameObject root) {
       InitUsd.Initialize();
+      _root = root;
 
       if (!root) {
         Debug.LogError("ExportRoot not assigned.");
@@ -46,6 +55,26 @@ namespace Unity.Formats.USD {
       try {
         if (string.IsNullOrEmpty(Clip.m_usdFile)) {
           Clip.UsdScene = Scene.Create();
+        } else if(Clip.IsUSDZ) {
+          // Keep the current directory to restore it at the end.
+          currentDir = Directory.GetCurrentDirectory();
+
+          // Setup a temporary directory to export the wanted USD file and zip it.
+          string tmpDirPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+          tmpDir = Directory.CreateDirectory(tmpDirPath);
+                    
+          // Get the usd file name to export and the usdz file name of the archive.
+          usdcFileName = Path.GetFileNameWithoutExtension(Clip.m_usdFile) + ".usdc";
+          usdzFileName = Path.GetFileName(Clip.m_usdFile);
+          var fi = new FileInfo(Clip.m_usdFile);
+          usdzFilePath = fi.FullName;
+
+          // Set the current working directory to the tmp directory to export with relative paths.
+          Directory.SetCurrentDirectory(tmpDirPath);
+
+          Clip.UsdScene = UsdzExporter.InitForSave(usdcFileName);
+
+          Debug.Log("tmp: " + tmpDirPath + "\n" + "usdc: " + usdcFileName + "\n" + "usdz: " + usdzFileName + "\n" + "usdz path: " + usdzFilePath);
         } else {
           Clip.UsdScene = Scene.Create(Clip.m_usdFile);
         }
@@ -93,7 +122,10 @@ namespace Unity.Formats.USD {
           Clip.UsdScene.Close();
           Clip.UsdScene = null;
         }
+        tmpDir.Delete(recursive: true);
         throw;
+      } finally {
+        Directory.SetCurrentDirectory(currentDir);
       }
     }
 
@@ -103,19 +135,43 @@ namespace Unity.Formats.USD {
         return;
       }
 
-      Clip.Context = new ExportContext();
-      Clip.UsdScene.EndTime = currentTime;
 
-      // In a real exporter, additional error handling should be added here.
-      if (!string.IsNullOrEmpty(Clip.m_usdFile)) {
-        // We could use SaveAs here, which is fine for small scenes, though it will require
-        // everything to fit in memory and another step where that memory is copied to disk.
-        Clip.UsdScene.Save();
+      try {
+        Directory.SetCurrentDirectory(tmpDir.FullName);
+
+        Clip.Context = new ExportContext();
+        Clip.UsdScene.EndTime = currentTime;
+        // In a real exporter, additional error handling should be added here.
+        if (!string.IsNullOrEmpty(Clip.m_usdFile)) {
+          // We could use SaveAs here, which is fine for small scenes, though it will require
+          // everything to fit in memory and another step where that memory is copied to disk.
+          Clip.UsdScene.Save();
+        }
+
+        // Release memory associated with the scene.
+        Clip.UsdScene.Close();
+        Clip.UsdScene = null;
+        if(Clip.IsUSDZ) {
+          SdfAssetPath assetPath = new SdfAssetPath(usdcFileName);
+          bool success = pxr.UsdCs.UsdUtilsCreateNewARKitUsdzPackage(assetPath, usdzFileName);
+
+          if (!success) {
+            Debug.LogError("Couldn't export " + _root.name + " to the usdz file: " + usdzFilePath);
+            return;
+          }
+
+          // needed if we export into temp folder first
+          File.Copy(usdzFileName, usdzFilePath, overwrite: true);
+        }
+      } finally {
+        // Clean up temp files.
+        Directory.SetCurrentDirectory(currentDir);
+        if (tmpDir.Exists) { 
+            tmpDir.Delete(recursive: true);
+        } else {
+            Debug.LogWarning("for some reason tmpDir " + tmpDir.FullName + " does not exist");
+        }
       }
-
-      // Release memory associated with the scene.
-      Clip.UsdScene.Close();
-      Clip.UsdScene = null;
     }
 
     void ProcessRecording(double currentTime, GameObject root) {

--- a/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
@@ -51,14 +51,13 @@ namespace Unity.Formats.USD {
         Clip.UsdScene.Close();
         Clip.UsdScene = null;
       }
-
+      // Keep the current directory to restore it at the end.
+      currentDir = Directory.GetCurrentDirectory();
       try {
         if (string.IsNullOrEmpty(Clip.m_usdFile)) {
           Clip.UsdScene = Scene.Create();
         } else if(Clip.IsUSDZ) {
-          // Keep the current directory to restore it at the end.
-          currentDir = Directory.GetCurrentDirectory();
-
+          
           // Setup a temporary directory to export the wanted USD file and zip it.
           string tmpDirPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
           tmpDir = Directory.CreateDirectory(tmpDirPath);
@@ -137,7 +136,8 @@ namespace Unity.Formats.USD {
 
 
       try {
-        Directory.SetCurrentDirectory(tmpDir.FullName);
+        if(tmpDir != null)
+            Directory.SetCurrentDirectory(tmpDir.FullName);
 
         Clip.Context = new ExportContext();
         Clip.UsdScene.EndTime = currentTime;
@@ -166,10 +166,10 @@ namespace Unity.Formats.USD {
       } finally {
         // Clean up temp files.
         Directory.SetCurrentDirectory(currentDir);
-        if (tmpDir.Exists) { 
+        if (tmpDir != null && tmpDir.Exists) { 
             tmpDir.Delete(recursive: true);
         } else {
-            Debug.LogWarning("for some reason tmpDir " + tmpDir.FullName + " does not exist");
+            Debug.LogWarning("for some reason tmpDir " + (tmpDir != null ? tmpDir.FullName : "null")+ " does not exist");
         }
       }
     }

--- a/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
@@ -104,15 +104,13 @@ namespace Unity.Formats.USD {
         Clip.Context.basisTransform = Clip.m_convertHandedness;
         Clip.Context.activePolicy = Clip.m_activePolicy;
         Clip.Context.exportMaterials = Clip.m_exportMaterials;
+        // USDZ is in centimeters.
+        Clip.Context.scale = Clip.IsUSDZ ? 100.0f : 1.0f;
 
         Clip.UsdScene.StartTime = currentTime;
 
         // Export the "default" frame, that is, all data which doesn't vary over time.
         Clip.UsdScene.Time = null;
-
-        // USDZ is in centimeters.
-        if (Clip.IsUSDZ)
-          root.transform.localScale = localScale * 100;
 
         SceneExporter.SyncExportContext(root, Clip.Context);
         SceneExporter.Export(root,
@@ -129,9 +127,6 @@ namespace Unity.Formats.USD {
           usdzTemporaryDir.Delete(recursive: true);
         throw;
       } finally {
-        // USDZ is in centimeters.
-        if (Clip.IsUSDZ)
-          root.transform.localScale = localScale;
         Directory.SetCurrentDirectory(currentDir);
       }
     }
@@ -193,12 +188,7 @@ namespace Unity.Formats.USD {
 
       Clip.UsdScene.Time = currentTime;
       Clip.Context.exportMaterials = false;
-      var localScale = root.transform.localScale;
-      if (Clip.IsUSDZ)
-        root.transform.localScale = localScale * 100;
       SceneExporter.Export(root, Clip.Context, zeroRootTransform: false);
-      if (Clip.IsUSDZ)
-        root.transform.localScale = localScale;
     }
 
     bool IsPlaying() {

--- a/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
@@ -53,6 +53,7 @@ namespace Unity.Formats.USD {
       }
       // Keep the current directory to restore it at the end.
       currentDir = Directory.GetCurrentDirectory();
+      var localScale = root.transform.localScale;
       try {
         if (string.IsNullOrEmpty(Clip.m_usdFile)) {
           Clip.UsdScene = Scene.Create();
@@ -110,6 +111,10 @@ namespace Unity.Formats.USD {
 
         // Export the "default" frame, that is, all data which doesn't vary over time.
         Clip.UsdScene.Time = null;
+
+        // USDZ is in centimeters.
+        if (Clip.IsUSDZ)
+          root.transform.localScale = localScale * 100;
         SceneExporter.SyncExportContext(root, Clip.Context);
         SceneExporter.Export(root,
                              Clip.Context,
@@ -124,6 +129,9 @@ namespace Unity.Formats.USD {
         tmpDir.Delete(recursive: true);
         throw;
       } finally {
+        // USDZ is in centimeters.
+        if (Clip.IsUSDZ)
+          root.transform.localScale = localScale;
         Directory.SetCurrentDirectory(currentDir);
       }
     }
@@ -187,7 +195,12 @@ namespace Unity.Formats.USD {
 
       Clip.UsdScene.Time = currentTime;
       Clip.Context.exportMaterials = false;
+      var localScale = root.transform.localScale;
+      if (Clip.IsUSDZ)
+        root.transform.localScale = localScale * 100;
       SceneExporter.Export(root, Clip.Context, zeroRootTransform: false);
+      if (Clip.IsUSDZ)
+        root.transform.localScale = localScale;
     }
 
     bool IsPlaying() {

--- a/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderClip.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderClip.cs
@@ -46,6 +46,8 @@ namespace Unity.Formats.USD {
 
     public ClipCaps clipCaps { get { return ClipCaps.None; } }
 
+    public bool IsUSDZ => !string.IsNullOrEmpty(m_usdFile) && m_usdFile.ToLowerInvariant().EndsWith(".usdz");
+
     public override Playable CreatePlayable(PlayableGraph graph, GameObject owner) {
       var ret = ScriptPlayable<UsdRecorderBehaviour>.Create(graph);
       var behaviour = ret.GetBehaviour();

--- a/package/com.unity.formats.usd/Tests/Editor/Data/004-USDZAnimationExport.unity
+++ b/package/com.unity.formats.usd/Tests/Editor/Data/004-USDZAnimationExport.unity
@@ -1,0 +1,463 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &549866996
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 549866999}
+  - component: {fileID: 549866998}
+  - component: {fileID: 549866997}
+  m_Layer: 0
+  m_Name: USDZAnimationExport
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!95 &549866997
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549866996}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 0}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!320 &549866998
+PlayableDirector:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549866996}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_PlayableAsset: {fileID: 11400000, guid: 2af2adfc2d77f814a90e5a332031c529, type: 2}
+  m_InitialState: 1
+  m_WrapMode: 2
+  m_DirectorUpdateMode: 1
+  m_InitialTime: 0
+  m_SceneBindings:
+  - key: {fileID: -94478401411134243, guid: 2af2adfc2d77f814a90e5a332031c529, type: 2}
+    value: {fileID: 549866997}
+  - key: {fileID: 6926050790031027073, guid: 2af2adfc2d77f814a90e5a332031c529, type: 2}
+    value: {fileID: 0}
+  m_ExposedReferences:
+    m_References:
+    - 72d837dd64c05594887d24d779fe1ce5: {fileID: 549866996}
+    - c387d1b9de81c084ebab7a18d63ad753: {fileID: 549866996}
+--- !u!4 &549866999
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549866996}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1888822790}
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &715002856
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 715002858}
+  - component: {fileID: 715002857}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &715002857
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 715002856}
+  m_Enabled: 1
+  serializedVersion: 9
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &715002858
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 715002856}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1265840039
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1265840042}
+  - component: {fileID: 1265840041}
+  - component: {fileID: 1265840040}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1265840040
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1265840039}
+  m_Enabled: 1
+--- !u!20 &1265840041
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1265840039}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1265840042
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1265840039}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1888822789
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1888822790}
+  - component: {fileID: 1888822793}
+  - component: {fileID: 1888822792}
+  - component: {fileID: 1888822791}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1888822790
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888822789}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_Children: []
+  m_Father: {fileID: 549866999}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1888822791
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888822789}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1888822792
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888822789}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 712db345d233cc945ad468a76bad3823, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1888822793
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888822789}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}

--- a/package/com.unity.formats.usd/Tests/Editor/Data/004-USDZAnimationExport.unity.meta
+++ b/package/com.unity.formats.usd/Tests/Editor/Data/004-USDZAnimationExport.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 56b1c5d87a4d0c048b2e8d2f2ad0a848
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/Editor/Data/004-USDZAnimationExportTimeline.playable
+++ b/package/com.unity.formats.usd/Tests/Editor/Data/004-USDZAnimationExportTimeline.playable
@@ -1,0 +1,596 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &-6110294829949530324
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Recorded
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 1.2
+        value: {x: 0, y: -360, z: 0}
+        inSlope: {x: 0, y: -334.8837, z: 0}
+        outSlope: {x: 0, y: -334.8837, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 2.15
+        value: {x: 0, y: -720, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: Cube
+  m_PositionCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 1.2
+        value: {x: 0, y: 0.344, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 2.15
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 3.1
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: Cube
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 2429296262
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+    - serializedVersion: 2
+      path: 2429296262
+      attribute: 4
+      script: {fileID: 0}
+      typeID: 4
+      customType: 4
+      isPPtrCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 3.1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.2
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.15
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 3.1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: Cube
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.2
+        value: 0.344
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.15
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 3.1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: Cube
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.2
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.15
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 3.1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: Cube
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.2
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.15
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: localEulerAnglesRaw.x
+    path: Cube
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.2
+        value: -360
+        inSlope: -334.8837
+        outSlope: -334.8837
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.15
+        value: -720
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: localEulerAnglesRaw.y
+    path: Cube
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.2
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.15
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: localEulerAnglesRaw.z
+    path: Cube
+    classID: 4
+    script: {fileID: 0}
+  m_EulerEditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalEulerAngles.x
+    path: Cube
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalEulerAngles.y
+    path: Cube
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalEulerAngles.z
+    path: Cube
+    classID: 4
+    script: {fileID: 0}
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []
+--- !u!114 &-2343652905669624772
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 341912d13765e7545a516855fb69687d, type: 3}
+  m_Name: UsdRecorderClip
+  m_EditorClassIdentifier: 
+  m_exportRoot:
+    exposedName: 72d837dd64c05594887d24d779fe1ce5
+    defaultValue: {fileID: 0}
+  m_exportMaterials: 1
+  m_convertHandedness: 1
+  m_activePolicy: 0
+  m_usdFile: Exports/recording2.usd
+--- !u!114 &-94478401411134243
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d21dcc2386d650c4597f3633c75a1f98, type: 3}
+  m_Name: Animation Track
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips: []
+  m_Markers:
+    m_Objects: []
+  m_InfiniteClipPreExtrapolation: 1
+  m_InfiniteClipPostExtrapolation: 1
+  m_InfiniteClipOffsetPosition: {x: 0, y: 0, z: 0}
+  m_InfiniteClipOffsetEulerAngles: {x: -0, y: 0, z: 0}
+  m_InfiniteClipTimeOffset: 0
+  m_InfiniteClipRemoveOffset: 0
+  m_InfiniteClipApplyFootIK: 1
+  mInfiniteClipLoop: 0
+  m_MatchTargetFields: 63
+  m_Position: {x: 0, y: 0, z: 0}
+  m_EulerAngles: {x: 0, y: 0, z: 0}
+  m_AvatarMask: {fileID: 0}
+  m_ApplyAvatarMask: 1
+  m_TrackOffset: 0
+  m_InfiniteClip: {fileID: -6110294829949530324}
+  m_OpenClipOffsetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_Rotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ApplyOffsets: 0
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfda56da833e2384a9677cd3c976a436, type: 3}
+  m_Name: 004-USDZAnimationExportTimeline
+  m_EditorClassIdentifier: 
+  m_Version: 0
+  m_Tracks:
+  - {fileID: -94478401411134243}
+  - {fileID: 6926050790031027073}
+  m_FixedDuration: 0
+  m_EditorSettings:
+    m_Framerate: 60
+  m_DurationMode: 0
+  m_MarkerTrack: {fileID: 0}
+--- !u!114 &6926050790031027073
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdb3781f83309f84dab54c78806353c0, type: 3}
+  m_Name: Usd Recorder Track
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips:
+  - m_Version: 1
+    m_Start: 0
+    m_ClipIn: 0
+    m_Asset: {fileID: -2343652905669624772}
+    m_Duration: 3.3833333333333333
+    m_TimeScale: 1
+    m_ParentTrack: {fileID: 6926050790031027073}
+    m_EaseInDuration: 0
+    m_EaseOutDuration: 0
+    m_BlendInDuration: 0
+    m_BlendOutDuration: 0
+    m_MixInCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_MixOutCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_BlendInCurveMode: 0
+    m_BlendOutCurveMode: 0
+    m_ExposedParameterNames: []
+    m_AnimationCurves: {fileID: 0}
+    m_Recordable: 0
+    m_PostExtrapolationMode: 0
+    m_PreExtrapolationMode: 0
+    m_PostExtrapolationTime: 0
+    m_PreExtrapolationTime: 0
+    m_DisplayName: UsdRecorderClip
+  m_Markers:
+    m_Objects: []

--- a/package/com.unity.formats.usd/Tests/Editor/Data/004-USDZAnimationExportTimeline.playable.meta
+++ b/package/com.unity.formats.usd/Tests/Editor/Data/004-USDZAnimationExportTimeline.playable.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2af2adfc2d77f814a90e5a332031c529
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/Editor/Data/AnimExportMat.mat
+++ b/package/com.unity.formats.usd/Tests/Editor/Data/AnimExportMat.mat
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AnimExportMat
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: f66c906430ef88342ac4637f0fa45a58, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/package/com.unity.formats.usd/Tests/Editor/Data/AnimExportMat.mat.meta
+++ b/package/com.unity.formats.usd/Tests/Editor/Data/AnimExportMat.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 712db345d233cc945ad468a76bad3823
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A common functionality for us for usd-unity-sdk is exporting content for use in Apple AR QuickLook.
For this, the menu item ("export as USDZ") is not sufficient as it does not export animation.
Additionally, exporting the timeline as USD and converting with the usdtools is also cumbersome, as it requires to remember to scale the object by 100x in Unity (since usdztools don't do the scale conversion).

To remedy this, I added the ability to UsdRecorderClip to also export USDZ (based on the file extension currently). This uses the same principles of changing working directory, packing in the end, and scaling the object by 100x. Resulting USDZ files are ready to be used directly in AR QuickLook in correct and expected scale (1 unity unit = 1 meter).

This could definitely be nicer in terms of UX (e.g. a file type dropdown for the clip), but it does the job and is (for us) a considerable QoL improvement.

Quite some code changes for the effect of having a single different letter :)
![image](https://user-images.githubusercontent.com/2693840/80239302-458be580-8660-11ea-9327-7696e0ef3a99.png)
