### PR TITLE
Fix animation export end time regression

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
@@ -145,14 +145,14 @@ namespace Unity.Formats.USD {
       }
 
       Clip.Context = new ExportContext();
-      Clip.UsdScene.EndTime = currentTime * kExportFrameRate ;
+      Clip.UsdScene.EndTime = currentTime * kExportFrameRate;
 
       try {
         if(Clip.IsUSDZ && usdzTemporaryDir != null)
           Directory.SetCurrentDirectory(usdzTemporaryDir.FullName);
 
         Clip.Context = new ExportContext();
-        Clip.UsdScene.EndTime = currentTime;
+        Clip.UsdScene.EndTime = currentTime * kExportFrameRate;
         // In a real exporter, additional error handling should be added here.
         if (!string.IsNullOrEmpty(Clip.m_usdFile)) {
           // We could use SaveAs here, which is fine for small scenes, though it will require

--- a/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
@@ -144,9 +144,6 @@ namespace Unity.Formats.USD {
         return;
       }
 
-      Clip.Context = new ExportContext();
-      Clip.UsdScene.EndTime = currentTime * kExportFrameRate;
-
       try {
         if(Clip.IsUSDZ && usdzTemporaryDir != null)
           Directory.SetCurrentDirectory(usdzTemporaryDir.FullName);


### PR DESCRIPTION
Missing multiplication by kExportFrameRate resulting in truncated exports.