### PR TITLE
Fix subdivision scheme and normal interpolation on export

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshExporter.cs
@@ -295,15 +295,26 @@ namespace Unity.Formats.USD {
         scene.Write(path, sample);
         UnityEngine.Profiling.Profiler.EndSample();
 
+        pxr.UsdPrim usdPrim = scene.GetPrimAtPath(path);
+
         // TODO: this is a bit of a half-measure, we need real support for primvar interpolation.
         // Set interpolation based on color count.
         if (sample.colors != null && sample.colors.Length == 1) {
-          pxr.UsdPrim usdPrim = scene.GetPrimAtPath(path);
           var colorPrimvar = new pxr.UsdGeomPrimvar(usdPrim.GetAttribute(pxr.UsdGeomTokens.primvarsDisplayColor));
           colorPrimvar.SetInterpolation(pxr.UsdGeomTokens.constant);
           var opacityPrimvar = new pxr.UsdGeomPrimvar(usdPrim.GetAttribute(pxr.UsdGeomTokens.primvarsDisplayOpacity));
           opacityPrimvar.SetInterpolation(pxr.UsdGeomTokens.constant);
         }
+
+        // for polygonal meshes, we do not want the default subdivision scheme of "catmull-clark" but instead "none"
+        // so that authored normals keep working.
+        var usdGeomMesh = new pxr.UsdGeomMesh(usdPrim);
+        usdGeomMesh.CreateSubdivisionSchemeAttr().Set(new pxr.TfToken("none"));
+
+        // explicitly set the normal interpolation here –
+        // default should be "vertex" anyways but seems some viewers don't respect the default
+        var normalInterp = new pxr.UsdGeomPrimvar(usdPrim.GetAttribute(pxr.UsdGeomTokens.normals));
+        normalInterp.SetInterpolation(pxr.UsdGeomTokens.vertex);
 
         string usdMaterialPath;
         if (exportContext.exportMaterials && sharedMaterial != null) {
@@ -328,9 +339,6 @@ namespace Unity.Formats.USD {
               faceTable.Add(new Vector3(tris[i + 1], tris[i], tris[i + 2]), i / 3);
             }
           }
-
-          var usdPrim = scene.GetPrimAtPath(path);
-          var usdGeomMesh = new pxr.UsdGeomMesh(usdPrim);
 
           // Process each subMesh and create a UsdGeomSubset of faces this subMesh targets.
           for (int si = 0; si < mesh.subMeshCount; si++) {


### PR DESCRIPTION
Set subdivision scheme to "none" and explicity set normal interpolation to "vertex". This fixes #192 but will need additional changes for "USD roundtrip" scenarios where keeping the subdiv scheme is desired. I think that is a problem for later since such a round trip would also require proper support for faceVarying attributes being carried through / reconstructed on export if desired. 

Current state of this should potentially be added to the docs to make it more clear what "roundtrip" means and what export currently does.

![Image from iOS](https://user-images.githubusercontent.com/2693840/87703563-5cdbfa00-c79b-11ea-9eea-9a74abc831d6.jpg)
![Image from iOS (1)](https://user-images.githubusercontent.com/2693840/87703565-5e0d2700-c79b-11ea-8565-71fe3bded212.jpg)
![Image from iOS](https://user-images.githubusercontent.com/2693840/87703566-5e0d2700-c79b-11ea-847e-0f7b2b0fcabf.png)
