### PR TITLE
USDU-13 add null check for scene.AccessMask

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImporter.cs
@@ -659,8 +659,8 @@ namespace Unity.Formats.USD {
                 NativeImporter.ImportObject(scene, go, scene.GetPrimAtPath(pathAndSample.path), importOptions);
                 XformImporter.BuildXform(pathAndSample.path, pathAndSample.sample, go, importOptions, scene);
                 var subsets = MeshImporter.ReadGeomSubsets(scene, pathAndSample.path);
-                MeshImporter.BuildMesh(pathAndSample.path, pathAndSample.sample, subsets, go, importOptions, 
-                             scene.AccessMask.Included.ContainsKey(pathAndSample.path));
+                bool isDynamic = scene.AccessMask != null ? scene.AccessMask.Included.ContainsKey(pathAndSample.path) : false;
+                MeshImporter.BuildMesh(pathAndSample.path, pathAndSample.sample, subsets, go, importOptions, isDynamic);
               } catch (System.Exception ex) {
                 Debug.LogException(
                     new ImportException("Error processing mesh <" + pathAndSample.path + ">", ex));


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** USDU-13

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->
Found while working on USDU-13. Add a null check for scene.AccessMask before calling BuildMesh. It is null when importing a usd file containing instances. 

## Testing

**Functional Testing status:**

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

Manual testing:
1. Create a cube in Maya with instances
2. Export cube with instances to USD
3. In Unity, import the file with USD > Import as GameObjects
4. Before fix: NullReferenceException and instances did not import
5. After fix: no error and instances import

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

This PR will not affect performance.

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
<!-- (Minimal / Low / Medium / High) -->

Minimal

**Halo Effect:**
<!-- (Minimal / Low / Medium / High) -->

Minimal

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_