### PR TITLE
JIRA: USDU-57 Field-of-view animation doesn't import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ TestProject/Logs
 TestProject/Assets/Plugins
 TestProject/Assets/Samples*
 inst-dbg/
+package/com.unity.formats.usd/TestRunnerOptions.json.meta

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/CameraImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/CameraImporter.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using UnityEngine;
+using USD.NET;
 using USD.NET.Unity;
 
 namespace Unity.Formats.USD {
@@ -25,13 +26,18 @@ namespace Unity.Formats.USD {
     /// <summary>
     /// Copy camera data from USD to Unity with the given import options.
     /// </summary>
-    public static void BuildCamera(CameraSample usdCamera,
-                                 GameObject go,
-                                 SceneImportOptions options) {
-      var cam = ImporterBase.GetOrAddComponent<Camera>(go);
-      usdCamera.CopyToCamera(cam, setTransform: false);
-      cam.nearClipPlane *= options.scale;
-      cam.farClipPlane *= options.scale;
+    public static void BuildCamera(pxr.SdfPath path,
+      CameraSample usdCamera,
+      GameObject go,
+      SceneImportOptions options, Scene scene)
+    {
+      if (scene.AccessMask == null || scene.IsPopulatingAccessMask || scene.AccessMask.Included.ContainsKey(path))
+      {
+        var cam = ImporterBase.GetOrAddComponent<Camera>(go);
+        usdCamera.CopyToCamera(cam, false);
+        cam.nearClipPlane *= options.scale;
+        cam.farClipPlane *= options.scale;
+      }
     }
   }
 }

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImporter.cs
@@ -591,11 +591,8 @@ namespace Unity.Formats.USD {
               go.transform.localRotation *= Quaternion.Euler(180.0f, 0.0f, 180.0f); 
             }
 
-            // The camera has many value-type parameters that need to be handled correctly when not
-            // not animated. For now, only the camera transform will animate, until this is fixed.
-            if (scene.AccessMask == null || scene.IsPopulatingAccessMask) {
-              CameraImporter.BuildCamera(pathAndSample.sample, go, importOptions);
-            }
+            CameraImporter.BuildCamera(pathAndSample.path, pathAndSample.sample, go, importOptions, scene);
+
           } catch (System.Exception ex) {
             Debug.LogException(
                 new ImportException("Error processing camera <" + pathAndSample.path + ">", ex));
@@ -708,7 +705,7 @@ namespace Unity.Formats.USD {
                 GameObject go = primMap[pathAndSample.path];
                 NativeImporter.ImportObject(scene, go, scene.GetPrimAtPath(pathAndSample.path), importOptions);
                 XformImporter.BuildXform(pathAndSample.path, pathAndSample.sample, go, importOptions, scene);
-                CameraImporter.BuildCamera(pathAndSample.sample, go, importOptions);
+                CameraImporter.BuildCamera(pathAndSample.path,pathAndSample.sample, go, importOptions, scene);
               } catch (System.Exception ex) {
                 Debug.LogException(
                     new ImportException("Error processing camera <" + pathAndSample.path + ">", ex));

--- a/package/com.unity.formats.usd/TestRunnerOptions.json
+++ b/package/com.unity.formats.usd/TestRunnerOptions.json
@@ -1,0 +1,3 @@
+{
+  "disableBatchMode": true
+}

--- a/package/com.unity.formats.usd/Tests/Runtime/AnimatedUSDFixture.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/AnimatedUSDFixture.cs
@@ -1,3 +1,4 @@
+#if UNITY_2019_4_OR_NEWER
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -171,3 +172,5 @@ namespace Unity.Formats.USD.Tests
         }
     }
 }
+
+#endif

--- a/package/com.unity.formats.usd/Tests/Runtime/AnimatedUSDFixture.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/AnimatedUSDFixture.cs
@@ -44,6 +44,7 @@ namespace Unity.Formats.USD.Tests
             m_filesToDelete.Add(usdRecorderAsset.m_usdFile);
             usdRecorderAsset.m_exportRoot = new ExposedReference<GameObject> {exposedName = Guid.NewGuid().ToString()};
             director.SetReferenceValue(usdRecorderAsset.m_exportRoot.exposedName, cam);
+            Time.captureDeltaTime = 1 / timeline.editorSettings.fps;
             director.Play();
             while (director.time <= 1.1)
                 yield return null;
@@ -77,8 +78,8 @@ namespace Unity.Formats.USD.Tests
             
             director.time = 1;
             director.Evaluate();
-            Assert.That(100, Is.EqualTo(cam.transform.localPosition.x).Within(0.1));
-            Assert.That(100, Is.EqualTo(cam.fieldOfView).Within(0.1));
+            Assert.That(100, Is.EqualTo(cam.transform.localPosition.x).Within(1e-5));
+            Assert.That(100, Is.EqualTo(cam.fieldOfView).Within(1e-5));
             
         }
 

--- a/package/com.unity.formats.usd/Tests/Runtime/AnimatedUSDFixture.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/AnimatedUSDFixture.cs
@@ -1,4 +1,3 @@
-#if UNITY_2019_4_OR_NEWER
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -36,7 +35,7 @@ namespace Unity.Formats.USD.Tests
             aTrack.CreateClip(clip).displayName = "CamClip";
             var cam = new GameObject("Camera").AddComponent<Camera>().gameObject;
             director.SetGenericBinding(aTrack, cam.AddComponent<Animator>());
-            var usdRecordTrack = timeline.CreateTrack<UsdRecorderTrack>();
+            var usdRecordTrack = timeline.CreateTrack<UsdRecorderTrack>(null, "");
             var usdRecorderClip = usdRecordTrack.CreateDefaultClip();
             usdRecorderClip.start = 0;
             usdRecorderClip.duration = 2;
@@ -45,7 +44,7 @@ namespace Unity.Formats.USD.Tests
             m_filesToDelete.Add(usdRecorderAsset.m_usdFile);
             usdRecorderAsset.m_exportRoot = new ExposedReference<GameObject> {exposedName = Guid.NewGuid().ToString()};
             director.SetReferenceValue(usdRecorderAsset.m_exportRoot.exposedName, cam);
-            Time.captureDeltaTime = 1 / timeline.editorSettings.fps;
+            Time.captureFramerate = (int)timeline.editorSettings.fps;
             director.Play();
             while (director.time <= 1.1)
                 yield return null;
@@ -62,7 +61,7 @@ namespace Unity.Formats.USD.Tests
         public void TestCamAnimation()
         {
             CreateTimeline(out var director, out var timeline);
-            var usdTrack = timeline.CreateTrack<UsdPlayableTrack>();
+            var usdTrack = timeline.CreateTrack<UsdPlayableTrack>(null,"");
             var clip = usdTrack.CreateDefaultClip();
             clip.duration = 2;
             var usdPlayableAsset = clip.asset as UsdPlayableAsset;
@@ -172,5 +171,3 @@ namespace Unity.Formats.USD.Tests
         }
     }
 }
-
-#endif

--- a/package/com.unity.formats.usd/Tests/Runtime/AnimatedUSDFixture.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/AnimatedUSDFixture.cs
@@ -86,6 +86,7 @@ namespace Unity.Formats.USD.Tests
         [TearDown]
         public void TearDown()
         {
+            Object.DestroyImmediate(m_usdRoot);
             foreach (var file in m_filesToDelete)
             {
                 File.Delete(file);

--- a/package/com.unity.formats.usd/Tests/Runtime/AnimatedUSDFixture.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/AnimatedUSDFixture.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Playables;
+using UnityEngine.TestTools;
+using UnityEngine.Timeline;
+using USD.NET;
+using Object = UnityEngine.Object;
+
+namespace Unity.Formats.USD.Tests
+{
+     class AnimatedUsdFixture
+    {
+        readonly List<string> m_filesToDelete = new List<string>();
+        UsdAsset m_usdRoot;
+        
+        [UnitySetUp]
+        public IEnumerator SetUp()
+        {
+            InitUsd.Initialize();
+            
+            var curve = AnimationCurve.Linear(0, 50, 1, 100);
+            var clip = new AnimationClip();
+            clip.SetCurve("", typeof(Transform), "localPosition.x", curve);
+            clip.SetCurve("", typeof(Camera), "field of view", curve);
+
+            CreateTimeline(out var director, out var timeline);
+            
+            var aTrack = timeline.CreateTrack<AnimationTrack>(null, "CubeAnimation");
+            aTrack.CreateClip(clip).displayName = "CamClip";
+            var cam = new GameObject("Camera").AddComponent<Camera>().gameObject;
+            director.SetGenericBinding(aTrack, cam.AddComponent<Animator>());
+            var usdRecordTrack = timeline.CreateTrack<UsdRecorderTrack>();
+            var usdRecorderClip = usdRecordTrack.CreateDefaultClip();
+            usdRecorderClip.start = 0;
+            usdRecorderClip.duration = 2;
+            var usdRecorderAsset = usdRecorderClip.asset as UsdRecorderClip;
+            usdRecorderAsset.m_usdFile = "Assets/" + Path.GetFileNameWithoutExtension(Path.GetTempFileName())+".usd";
+            m_filesToDelete.Add(usdRecorderAsset.m_usdFile);
+            usdRecorderAsset.m_exportRoot = new ExposedReference<GameObject> {exposedName = Guid.NewGuid().ToString()};
+            director.SetReferenceValue(usdRecorderAsset.m_exportRoot.exposedName, cam);
+            director.Play();
+            while (director.time <= 1.1)
+                yield return null;
+            director.Stop();
+            yield return null;
+            var stage = pxr.UsdStage.Open(usdRecorderAsset.m_usdFile, pxr.UsdStage.InitialLoadSet.LoadAll);
+            var scene =  Scene.Open(stage);
+            m_usdRoot = ImportSceneAsGameObject(scene).GetComponent<UsdAsset>();
+            scene.Close();
+            m_usdRoot.name = "Potato";
+        }
+
+        [Test]
+        public void TestCamAnimation()
+        {
+            CreateTimeline(out var director, out var timeline);
+            var usdTrack = timeline.CreateTrack<UsdPlayableTrack>();
+            var clip = usdTrack.CreateDefaultClip();
+            clip.duration = 2;
+            var usdPlayableAsset = clip.asset as UsdPlayableAsset;
+            usdPlayableAsset.SourceUsdAsset = new ExposedReference<UsdAsset> {exposedName = Guid.NewGuid().ToString()};
+            director.SetGenericBinding(usdTrack, m_usdRoot);
+            director.SetReferenceValue(usdPlayableAsset.SourceUsdAsset.exposedName, m_usdRoot);
+
+            var cam = m_usdRoot.gameObject.GetComponent<Camera>();
+            director.time = 0;
+            director.Evaluate();
+
+            Assert.That(50, Is.EqualTo(cam.transform.localPosition.x).Within(1e-5));
+            Assert.That(50, Is.EqualTo(cam.fieldOfView).Within(1e-5));
+            
+            director.time = 1;
+            director.Evaluate();
+            Assert.That(100, Is.EqualTo(cam.transform.localPosition.x).Within(0.1));
+            Assert.That(100, Is.EqualTo(cam.fieldOfView).Within(0.1));
+            
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var file in m_filesToDelete)
+            {
+                File.Delete(file);
+            }
+            m_filesToDelete.Clear();
+        }
+
+        static void CreateTimeline(out PlayableDirector director, out TimelineAsset timeline)
+        {
+            director = new GameObject("Timeline").AddComponent<PlayableDirector>();
+            timeline = ScriptableObject.CreateInstance<TimelineAsset>();
+            director.playableAsset = timeline;
+        }
+        
+        static GameObject ImportSceneAsGameObject(Scene scene, SceneImportOptions importOptions=null)
+        {
+            string path = scene.FilePath;
+
+            // Time-varying data is not supported and often scenes are written without "Default" time
+            // values, which makes setting an arbitrary time safer (because if only default was authored
+            // the time will be ignored and values will resolve to default time automatically).
+            scene.Time = 1.0;
+
+            if (importOptions == null)
+            {
+                importOptions = new SceneImportOptions();
+                importOptions.changeHandedness = BasisTransformation.SlowAndSafe;
+                importOptions.materialImportMode = MaterialImportMode.ImportDisplayColor;
+                importOptions.usdRootPath = GetDefaultRoot(scene);
+            }
+
+            GameObject root = new GameObject(GetObjectName(importOptions.usdRootPath, path));
+
+            if (Selection.gameObjects.Length > 0) {
+                root.transform.SetParent(Selection.gameObjects[0].transform);
+            }
+
+            try
+            {
+                UsdToGameObject(root, scene, importOptions);
+                return root;
+            }
+            catch (SceneImporter.ImportException)
+            {
+                Object.DestroyImmediate(root);
+                return null;
+            }
+        }
+
+        static pxr.SdfPath GetDefaultRoot(Scene scene) {
+            // We can't safely assume the default prim is the model root, because Alembic files will
+            // always have a default prim set arbitrarily.
+
+            // If there is only one root prim, reference this prim.
+            var children = scene.Stage.GetPseudoRoot().GetChildren().ToList();
+            if (children.Count == 1) {
+                return children[0].GetPath();
+            }
+
+            // Otherwise there are 0 or many root prims, in this case the best option is to reference
+            // them all, to avoid confusion.
+            return pxr.SdfPath.AbsoluteRootPath();
+        }
+        static GameObject UsdToGameObject(GameObject parent,
+            Scene scene,
+            SceneImportOptions importOptions) {
+            try {
+                SceneImporter.ImportUsd(parent, scene, new PrimMap(), importOptions);
+            } finally {
+                scene.Close();
+            }
+
+            return parent;
+        }
+        static string GetObjectName(pxr.SdfPath rootPrimName, string path) {
+            return pxr.UsdCs.TfIsValidIdentifier(rootPrimName.GetName())
+                ? rootPrimName.GetName()
+                : GetObjectName(path);
+        }
+        static string GetObjectName(string path) {
+            return IntrinsicTypeConverter.MakeValidIdentifier(Path.GetFileNameWithoutExtension(path));
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Runtime/AnimatedUSDFixture.cs.meta
+++ b/package/com.unity.formats.usd/Tests/Runtime/AnimatedUSDFixture.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 22a44a156e68475b8f7aa273e3220cf1
+timeCreated: 1603819835

--- a/package/com.unity.formats.usd/Tests/Runtime/Unity.Formats.USD.Tests.asmdef
+++ b/package/com.unity.formats.usd/Tests/Runtime/Unity.Formats.USD.Tests.asmdef
@@ -2,9 +2,10 @@
     "name": "Unity.Formats.USD.Tests",
     "references": [
         "Unity.Formats.USD.Runtime",
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner",
         "Unity.Timeline"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
     ],
     "includePlatforms": [
         "Editor",
@@ -16,13 +17,8 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "USD.NET.dll",
-        "nunit.framework.dll"
+        "USD.NET.dll"
     ],
-    "autoReferenced": false,
-    "defineConstraints": [
-        "UNITY_INCLUDE_TESTS"
-    ],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "autoReferenced": true,
+    "defineConstraints": []
 }

--- a/package/com.unity.formats.usd/Tests/Runtime/Unity.Formats.USD.Tests.asmdef
+++ b/package/com.unity.formats.usd/Tests/Runtime/Unity.Formats.USD.Tests.asmdef
@@ -1,10 +1,10 @@
 {
     "name": "Unity.Formats.USD.Tests",
     "references": [
-        "Unity.Formats.USD.Runtime"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "Unity.Formats.USD.Runtime",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Unity.Timeline"
     ],
     "includePlatforms": [
         "Editor",
@@ -16,8 +16,13 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "USD.NET.dll"
+        "USD.NET.dll",
+        "nunit.framework.dll"
     ],
-    "autoReferenced": true,
-    "defineConstraints": []
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
The problem was an access mask missing feature.

Upon writing the unit test I noticed that the USD recorder is not very frame accurate: the generated use files do not coincide 100% with the animation (about one frame off), thus the very large epsilons in the Assertion.