### PR TITLE
Fix UsdAsset not dirty (USDU-131)

### DIFF
--- a/package/com.unity.formats.usd/CHANGELOG.md
+++ b/package/com.unity.formats.usd/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - Set material name in Unity to match the material name in the USD file on import.
 - Fixed USDPayload's "Is Loaded" field in the inspector staying at false even when the payload has been loaded.
+- Fix UsdAsset not saving changes made in the inspector (simple view).
 
 ## [1.0.4-preview.1] - 2020-07-24
 ### Changed

--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
@@ -208,6 +208,7 @@ namespace Unity.Formats.USD {
 
       GUILayout.Label("Import Settings", EditorStyles.boldLabel);
 
+      EditorGUI.BeginChangeCheck();
       EditorGUILayout.BeginHorizontal();
 
       var op = LinearUnits.Custom;
@@ -265,7 +266,8 @@ namespace Unity.Formats.USD {
       usdAsset.m_importMeshes = EditorGUILayout.Toggle("Import Meshes", usdAsset.m_importMeshes);
       usdAsset.m_importSkinning = EditorGUILayout.Toggle("Import Skinning", usdAsset.m_importSkinning);
       usdAsset.m_importTransforms = EditorGUILayout.Toggle("Import Transforms", usdAsset.m_importTransforms);
-
+      if (EditorGUI.EndChangeCheck())
+         EditorUtility.SetDirty(usdAsset);
     }
 
     private void ReloadFromUsd(UsdAsset stageRoot, bool forceRebuild) {


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** USDU-131

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->

UsdAsset's inspector is made up for two views: simple and advanced views.
- Simple view is a custom inspector defined in UsdAssetEditor.DrawSimpleView().
- Advanced view is the component's default inspector.

The simple view wasn't checking if modifications where made from the inspector to mark the data dirty. Thus, modifications couldn't get saved in scenes or prefabs.

## Testing

**Functional Testing status:** Manual tests in Prefab stage and Main stage.

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

**Performance Testing status:** N/A

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:** Minimal
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:** Minimal
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [x] Add entry in CHANGELOG.md _(if applicable)_