### PR TITLE
Fix USD refresh not always working in Prefab stage (USDU-128)

### DIFF
--- a/package/com.unity.formats.usd/CHANGELOG.md
+++ b/package/com.unity.formats.usd/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - Set material name in Unity to match the material name in the USD file on import.
 - Fixed USDPayload's "Is Loaded" field in the inspector staying at false even when the payload has been loaded.
+- Fix UsdAsset not properly refreshing the asset within the Prefab stage.
 
 ## [1.0.4-preview.1] - 2020-07-24
 ### Changed

--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
@@ -501,6 +501,11 @@ namespace Unity.Formats.USD {
         if (options.forceRebuild) {
           DestroyAllImportedObjects();
         }
+
+        m_lastScene = null;
+        m_lastPrimMap = null;
+        m_lastAccessMask = null;
+
         SceneImporter.ImportUsd(root, GetScene(), new PrimMap(), options);
 
 #if UNITY_EDITOR

--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
@@ -394,9 +394,8 @@ namespace Unity.Formats.USD {
           stage = pxr.UsdStage.Open(usdFullPath, pxr.UsdStage.InitialLoadSet.LoadAll);
         }
 
+        ClearLastData();
         m_lastScene = Scene.Open(stage);
-        m_lastPrimMap = null;
-        m_lastAccessMask = null;
 
         // TODO: This is potentially horrible in terms of performance, LoadAndUnload should be used
         // instead, but the binding is not complete.
@@ -442,6 +441,16 @@ namespace Unity.Formats.USD {
     private void DestroyComponent(Component comp) {
       if (!comp) { return; }
       Component.DestroyImmediate(comp);
+    }
+    
+    /// <summary>
+    /// Clear internal data.
+    /// Call to <see cref="GetScene">GetScene()</see> to update them with the latest USD data.
+    /// </summary>
+    private void ClearLastData() {
+      m_lastScene = null;
+      m_lastPrimMap = null;
+      m_lastAccessMask = null;
     }
 
     /// <summary>
@@ -502,10 +511,7 @@ namespace Unity.Formats.USD {
           DestroyAllImportedObjects();
         }
 
-        m_lastScene = null;
-        m_lastPrimMap = null;
-        m_lastAccessMask = null;
-
+        ClearLastData();
         SceneImporter.ImportUsd(root, GetScene(), new PrimMap(), options);
 
 #if UNITY_EDITOR
@@ -524,10 +530,7 @@ namespace Unity.Formats.USD {
           DestroyAllImportedObjects();
         }
 
-        m_lastScene = null;
-        m_lastPrimMap = null;
-        m_lastAccessMask = null;
-
+        ClearLastData();
         SceneImporter.ImportUsd(root, GetScene(), new PrimMap(), options);
       }
     }

--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
@@ -394,8 +394,9 @@ namespace Unity.Formats.USD {
           stage = pxr.UsdStage.Open(usdFullPath, pxr.UsdStage.InitialLoadSet.LoadAll);
         }
 
-        ClearLastData();
         m_lastScene = Scene.Open(stage);
+        m_lastPrimMap = null;
+        m_lastAccessMask = null;
 
         // TODO: This is potentially horrible in terms of performance, LoadAndUnload should be used
         // instead, but the binding is not complete.


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** USDU-128

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->

After a USD has been loaded into a Prefab, going in Prefab Stage and refreshing the UsdAsset with Payload Policy set to Load All doesn't work.

Turns out, the code path that is being used for prefab doesn't unreference the scene before updating the data. It makes the logic re-use the cache data instead of re-opening the scene with a LoadAll policy.

## Testing

**Functional Testing status:** Manuals tests identical as the reproduction steps of the issue.

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

**Performance Testing status:** N/A

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:** Low
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:** Low
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [x] Add entry in CHANGELOG.md _(if applicable)_