### PR TITLE
Samples maintenance (USDU-65 USDU-136)

### DIFF
--- a/package/com.unity.formats.usd/Editor/Utils.meta
+++ b/package/com.unity.formats.usd/Editor/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f035652d61b6f48d88f1fea020a72b2c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Editor/Utils/PackageUtils.cs
+++ b/package/com.unity.formats.usd/Editor/Utils/PackageUtils.cs
@@ -8,6 +8,46 @@ namespace Unity.Formats.USD
 {
     public static class PackageUtils
     {
+
+        /// <summary>
+        /// Utils function to get the relative path of a file considering a base folder
+        /// </summary>
+        public static string GetRelativeFolderPath(string baseFolderPath, string filePath = "")
+        {
+            const string universalSeparator = @"/";
+            const string windowsSeparator = @"\";
+
+            // Conforming paths to ease next steps
+            filePath = filePath.Replace(windowsSeparator, universalSeparator);
+            baseFolderPath = baseFolderPath.Replace(windowsSeparator, universalSeparator);
+
+            // baseFolderPath must end with a slash to indicate folder
+            baseFolderPath = baseFolderPath.TrimEnd();
+            if (!baseFolderPath.EndsWith(universalSeparator))
+            {
+                baseFolderPath += universalSeparator;
+            }
+
+            // Using URIs to find the relative path
+            var sampleFolderAbsoluteURI = new Uri(Path.GetDirectoryName(filePath));
+            var projectFolderAbsoluteURI = new Uri(baseFolderPath);
+            var sampleFolderRelativePath =
+                Uri.UnescapeDataString(
+                    projectFolderAbsoluteURI.MakeRelativeUri(sampleFolderAbsoluteURI).ToString()
+                        .Replace('/', Path.DirectorySeparatorChar)
+                );
+            return sampleFolderRelativePath;
+        }
+
+        /// <summary>
+        /// Utils function to get the relative path of the current caller with current Unity directory as a base folder
+        /// </summary>
+        public static string GetCallerRelativeToProjectFolderPath([CallerFilePath] string filePath = "")
+        {
+            return GetRelativeFolderPath(Directory.GetCurrentDirectory(), filePath);
+        }
+
+
         /// <summary>
         /// Utils function to get the absolute path of a MonoBehaviour
         /// </summary>

--- a/package/com.unity.formats.usd/Editor/Utils/PackageUtils.cs
+++ b/package/com.unity.formats.usd/Editor/Utils/PackageUtils.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using UnityEditor;
+using UnityEngine;
+
+namespace Unity.Formats.USD
+{
+    public static class PackageUtils
+    {
+        /// <summary>
+        /// Utils function to get the absolute path of a MonoBehaviour
+        /// </summary>
+        public static string GetMonoBehaviourPath(MonoBehaviour mono)
+        {
+            var script = MonoScript.FromMonoBehaviour(mono);
+            return AssetDatabase.GetAssetPath(script);
+        }
+
+        /// <summary>
+        /// Utils function to get the absolute path of the parent folder of a MonoBehaviour
+        /// </summary>
+        public static string GetMonoBehaviourFolderPath(MonoBehaviour mono)
+        {
+            return Directory.GetParent(GetMonoBehaviourPath(mono)).FullName;
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Editor/Utils/PackageUtils.cs
+++ b/package/com.unity.formats.usd/Editor/Utils/PackageUtils.cs
@@ -46,23 +46,5 @@ namespace Unity.Formats.USD
         {
             return GetRelativeFolderPath(Directory.GetCurrentDirectory(), filePath);
         }
-
-
-        /// <summary>
-        /// Utils function to get the absolute path of a MonoBehaviour
-        /// </summary>
-        public static string GetMonoBehaviourPath(MonoBehaviour mono)
-        {
-            var script = MonoScript.FromMonoBehaviour(mono);
-            return AssetDatabase.GetAssetPath(script);
-        }
-
-        /// <summary>
-        /// Utils function to get the absolute path of the parent folder of a MonoBehaviour
-        /// </summary>
-        public static string GetMonoBehaviourFolderPath(MonoBehaviour mono)
-        {
-            return Directory.GetParent(GetMonoBehaviourPath(mono)).FullName;
-        }
     }
 }

--- a/package/com.unity.formats.usd/Editor/Utils/PackageUtils.cs.meta
+++ b/package/com.unity.formats.usd/Editor/Utils/PackageUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2085f19c60b074b2582a726e6d01f52e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Samples/ExportMesh/ExportMesh.unity
+++ b/package/com.unity.formats.usd/Samples/ExportMesh/ExportMesh.unity
@@ -2770,7 +2770,6 @@ GameObject:
   m_Component:
   - component: {fileID: 536733509}
   - component: {fileID: 536733508}
-  - component: {fileID: 536733507}
   - component: {fileID: 536733506}
   - component: {fileID: 536733505}
   m_Layer: 0
@@ -2788,13 +2787,6 @@ AudioListener:
   m_GameObject: {fileID: 536733504}
   m_Enabled: 1
 --- !u!124 &536733506
-Behaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 536733504}
-  m_Enabled: 1
---- !u!92 &536733507
 Behaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/package/com.unity.formats.usd/Samples/HelloUsd/HelloUsd.unity
+++ b/package/com.unity.formats.usd/Samples/HelloUsd/HelloUsd.unity
@@ -224,7 +224,6 @@ GameObject:
   m_Component:
   - component: {fileID: 822688662}
   - component: {fileID: 822688661}
-  - component: {fileID: 822688660}
   - component: {fileID: 822688659}
   - component: {fileID: 822688658}
   m_Layer: 0
@@ -242,13 +241,6 @@ AudioListener:
   m_GameObject: {fileID: 822688657}
   m_Enabled: 1
 --- !u!124 &822688659
-Behaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 822688657}
-  m_Enabled: 1
---- !u!92 &822688660
 Behaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}

--- a/package/com.unity.formats.usd/Samples/ImportMaterials/ImportMaterials.unity
+++ b/package/com.unity.formats.usd/Samples/ImportMaterials/ImportMaterials.unity
@@ -273,7 +273,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1755182419}
   - component: {fileID: 1755182418}
-  - component: {fileID: 1755182417}
   - component: {fileID: 1755182416}
   - component: {fileID: 1755182415}
   m_Layer: 0
@@ -291,13 +290,6 @@ AudioListener:
   m_GameObject: {fileID: 1755182414}
   m_Enabled: 1
 --- !u!124 &1755182416
-Behaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1755182414}
-  m_Enabled: 1
---- !u!92 &1755182417
 Behaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}

--- a/package/com.unity.formats.usd/Samples/ImportMaterials/ImportMaterialsExample.cs
+++ b/package/com.unity.formats.usd/Samples/ImportMaterials/ImportMaterialsExample.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using System.IO;
 using UnityEngine;
 using USD.NET;
 using USD.NET.Unity;
@@ -21,6 +22,7 @@ namespace Unity.Formats.USD.Examples {
 
   public class ImportMaterialsExample : MonoBehaviour {
     private const string kCubePath = "/Model/Geom/Cube";
+    private static string m_localPath;
 
     // The USD Shader ID is used to index into this map to find the corresponding ShaderPair,
     // i.e. the Unity / USD shader pair that should be instantiated for the ID.
@@ -77,6 +79,9 @@ namespace Unity.Formats.USD.Examples {
     // Also See: https://docs.unity3d.com/Manual/MaterialsAccessingViaScript.html
     //
     void Start() {
+      // Get the current local path
+      m_localPath = PackageUtils.GetCallerRelativeToProjectFolderPath();
+
       // Create a scene for this test, but could also be read from disk.
       Scene usdScene = CreateSceneWithShading();
 
@@ -241,7 +246,7 @@ namespace Unity.Formats.USD.Examples {
       var detailNormalMapPath = "/Model/Materials/SimpleMat/DetailNormalMap";
       var detailMaskPath = "/Model/Materials/SimpleMat/DetailMask";
 
-      var textureFilePath = @"Assets/Samples/USD/1.0.3-preview.1/ImportMaterials/Textures/";
+      var textureFilePath = Path.Combine(m_localPath, "Textures");
 
       var cube = new CubeSample();
       cube.size = 7;
@@ -298,35 +303,35 @@ namespace Unity.Formats.USD.Examples {
       // Setup Textures.
       //
       var albedoTexture = new Texture2DSample();
-      albedoTexture.sourceFile.defaultValue = textureFilePath + "albedoMap.png";
+      albedoTexture.sourceFile.defaultValue = Path.Combine(textureFilePath, "albedoMap.png");
       albedoTexture.sRgb = true;
       
       var normalTexture = new Texture2DSample();
-      normalTexture.sourceFile.defaultValue = textureFilePath + "normalMap.png";
+      normalTexture.sourceFile.defaultValue = Path.Combine(textureFilePath, "normalMap.png");
       normalTexture.sRgb = true;
       
       var emissionTexture = new Texture2DSample();
-      emissionTexture.sourceFile.defaultValue = textureFilePath + "emissionMap.png";
+      emissionTexture.sourceFile.defaultValue = Path.Combine(textureFilePath, "emissionMap.png");
       emissionTexture.sRgb = true;
 
       var metallicTexture = new Texture2DSample();
-      metallicTexture.sourceFile.defaultValue = textureFilePath + "metallicMap.png";
+      metallicTexture.sourceFile.defaultValue = Path.Combine(textureFilePath, "metallicMap.png");
       metallicTexture.sRgb = true;
 
       var occlusionTexture = new Texture2DSample();
-      occlusionTexture.sourceFile.defaultValue = textureFilePath + "occlusionMap.png";
+      occlusionTexture.sourceFile.defaultValue = Path.Combine(textureFilePath, "occlusionMap.png");
       occlusionTexture.sRgb = true;
 
       var parallaxTexture = new Texture2DSample();
-      parallaxTexture.sourceFile.defaultValue = textureFilePath + "parallaxMap.png";
+      parallaxTexture.sourceFile.defaultValue = Path.Combine(textureFilePath, "parallaxMap.png");
       parallaxTexture.sRgb = true;
 
       var detailNormalTexture = new Texture2DSample();
-      detailNormalTexture.sourceFile.defaultValue = textureFilePath + "detailMap.png";
+      detailNormalTexture.sourceFile.defaultValue = Path.Combine(textureFilePath, "detailMap.png");
       detailNormalTexture.sRgb = true;
 
       var detailMaskTexture = new Texture2DSample();
-      detailMaskTexture.sourceFile.defaultValue = textureFilePath + "metallicMap.png";
+      detailMaskTexture.sourceFile.defaultValue = Path.Combine(textureFilePath, "metallicMap.png");
       detailMaskTexture.sRgb = true;
 
       //

--- a/package/com.unity.formats.usd/Samples/ImportMaterials/Unity.Formats.USD.ImportMaterials.asmdef
+++ b/package/com.unity.formats.usd/Samples/ImportMaterials/Unity.Formats.USD.ImportMaterials.asmdef
@@ -1,6 +1,7 @@
 {
     "name": "Unity.Formats.USD.ImportMaterials",
     "references": [
+        "Unity.Formats.USD.Editor",
         "Unity.Formats.USD.Runtime"
     ],
     "optionalUnityReferences": [

--- a/package/com.unity.formats.usd/Samples/ImportMesh/ImportMesh.unity
+++ b/package/com.unity.formats.usd/Samples/ImportMesh/ImportMesh.unity
@@ -373,7 +373,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6b9422ac107eb345ba17ec50a29caf4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_usdFile: Samples/USD/1.0.3-preview.1/ImportMesh/mesh.usd
+  m_usdFile:
   m_material: {fileID: 2100000, guid: 5a4399f9b4f4d774dbc7921697839d7e, type: 2}
   m_usdTime: 0
   m_changeHandedness: 0

--- a/package/com.unity.formats.usd/Samples/ImportMesh/ImportMesh.unity
+++ b/package/com.unity.formats.usd/Samples/ImportMesh/ImportMesh.unity
@@ -130,7 +130,6 @@ GameObject:
   m_Component:
   - component: {fileID: 536733509}
   - component: {fileID: 536733508}
-  - component: {fileID: 536733507}
   - component: {fileID: 536733506}
   - component: {fileID: 536733505}
   m_Layer: 0
@@ -149,14 +148,6 @@ AudioListener:
   m_GameObject: {fileID: 536733504}
   m_Enabled: 1
 --- !u!124 &536733506
-Behaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 536733504}
-  m_Enabled: 1
---- !u!92 &536733507
 Behaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/package/com.unity.formats.usd/Samples/ImportMesh/ImportMeshExample.cs
+++ b/package/com.unity.formats.usd/Samples/ImportMesh/ImportMeshExample.cs
@@ -14,6 +14,7 @@
 
 using System;
 using UnityEngine;
+using System.IO;
 using USD.NET;
 
 namespace Unity.Formats.USD.Examples {
@@ -25,6 +26,7 @@ namespace Unity.Formats.USD.Examples {
   [ExecuteInEditMode]
   public class ImportMeshExample : MonoBehaviour {
     public string m_usdFile;
+    private const string K_DEFAULT_MESH = "mesh.usd";
     public Material m_material;
 
     // The range is arbitrary, but adding it provides a slider in the UI.
@@ -48,13 +50,12 @@ namespace Unity.Formats.USD.Examples {
     void Start() {
       InitUsd.Initialize();
       m_lastTime = m_usdTime;
+      if (string.IsNullOrEmpty(m_usdFile))
+        m_usdFile = Path.Combine(PackageUtils.GetMonoBehaviourFolderPath(this), K_DEFAULT_MESH);
     }
 
-    void Update() {
-      m_usdFile = m_usdFile.Replace("\"", "");
-      if (!System.IO.Path.IsPathRooted(m_usdFile)) {
-        m_usdFile = Application.dataPath + "/" + m_usdFile;
-      }
+    void Update()
+    {
       if (string.IsNullOrEmpty(m_usdFile)) {
         if (m_scene == null) {
           return;
@@ -71,11 +72,6 @@ namespace Unity.Formats.USD.Examples {
       }
 
       try {
-        // Does the path exist?
-        if (!System.IO.File.Exists(m_usdFile)) {
-          throw new System.IO.FileNotFoundException(m_usdFile);
-        }
-
         m_lastTime = m_usdTime;
 
         // Clear out the old scene.
@@ -118,6 +114,15 @@ namespace Unity.Formats.USD.Examples {
         enabled = false;
         throw;
       }
+    }
+    private void OnValidate()
+    {
+      if (!string.IsNullOrEmpty(m_usdFile) && !System.IO.File.Exists(m_usdFile))
+      {
+        enabled = false;
+        throw new System.IO.FileNotFoundException(m_usdFile);
+      }
+      enabled = true;
     }
 
     // Destroy all previously created objects.

--- a/package/com.unity.formats.usd/Samples/ImportMesh/ImportMeshExample.cs
+++ b/package/com.unity.formats.usd/Samples/ImportMesh/ImportMeshExample.cs
@@ -51,7 +51,7 @@ namespace Unity.Formats.USD.Examples {
       InitUsd.Initialize();
       m_lastTime = m_usdTime;
       if (string.IsNullOrEmpty(m_usdFile))
-        m_usdFile = Path.Combine(PackageUtils.GetMonoBehaviourFolderPath(this), K_DEFAULT_MESH);
+        m_usdFile = Path.Combine(PackageUtils.GetCallerRelativeToProjectFolderPath(), K_DEFAULT_MESH);
     }
 
     void Update()

--- a/package/com.unity.formats.usd/Samples/ImportMesh/Unity.Formats.USD.ImportMesh.asmdef
+++ b/package/com.unity.formats.usd/Samples/ImportMesh/Unity.Formats.USD.ImportMesh.asmdef
@@ -1,6 +1,7 @@
 {
     "name": "Unity.Formats.USD.ImportMesh",
     "references": [
+        "Unity.Formats.USD.Editor",
         "Unity.Formats.USD.Runtime"
     ],
     "optionalUnityReferences": [

--- a/package/com.unity.formats.usd/Samples/UsdTimelinePlayable/SetDefaultUSDMesh.cs
+++ b/package/com.unity.formats.usd/Samples/UsdTimelinePlayable/SetDefaultUSDMesh.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using UnityEngine;
+using System.IO;
+using USD.NET;
+
+ namespace Unity.Formats.USD.Examples
+ {
+   /// <summary>Fill in a default USD Asset in case the user didn't choose one
+   /// </summary>
+   [ExecuteInEditMode, RequireComponent(typeof(UsdAsset))]
+   public class SetDefaultUSDMesh : MonoBehaviour
+   {
+     private const string K_DEFAULT_MESH = "mesh.usd";
+
+     void Start()
+     {
+       var asset = GetComponent<UsdAsset>();
+       if (string.IsNullOrEmpty(asset.usdFullPath))
+       {
+         asset.usdFullPath = Path.Combine(PackageUtils.GetCallerRelativeToProjectFolderPath(), K_DEFAULT_MESH);
+       }
+     }
+   }
+ }

--- a/package/com.unity.formats.usd/Samples/UsdTimelinePlayable/SetDefaultUSDMesh.cs.meta
+++ b/package/com.unity.formats.usd/Samples/UsdTimelinePlayable/SetDefaultUSDMesh.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6cababbffd53bec479dc9d47daf0353c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Samples/UsdTimelinePlayable/Unity.Formats.USD.UsdTimelinePlayable.asmdef
+++ b/package/com.unity.formats.usd/Samples/UsdTimelinePlayable/Unity.Formats.USD.UsdTimelinePlayable.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "Unity.Formats.USD.UsdTimelinePlayable",
+    "references": [
+        "Unity.Formats.USD.Editor",
+        "Unity.Formats.USD.Runtime"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor",
+        "LinuxStandalone64",
+        "macOSStandalone",
+        "WindowsStandalone64"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "USD.NET.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/package/com.unity.formats.usd/Samples/UsdTimelinePlayable/Unity.Formats.USD.UsdTimelinePlayable.asmdef.meta
+++ b/package/com.unity.formats.usd/Samples/UsdTimelinePlayable/Unity.Formats.USD.UsdTimelinePlayable.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7a25b7735e478e04ea517e32e8c4dba3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Samples/UsdTimelinePlayable/UsdTimelinePlayable.unity
+++ b/package/com.unity.formats.usd/Samples/UsdTimelinePlayable/UsdTimelinePlayable.unity
@@ -21079,6 +21079,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1786737527}
   - component: {fileID: 1786737528}
+  - component: {fileID: 1786737529}
   m_Layer: 0
   m_Name: testRecording
   m_TagString: Untagged
@@ -21113,7 +21114,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4aff4833db8e2b14aa0f0b6071c41e5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_usdFile: Assets/Samples/USD/1.0.3-preview.1/UsdTimelinePlayable/mesh.usd
+  m_usdFile:
   m_projectAssetPath: Assets/
   m_usdRootPath: /
   m_usdTimeOffset: 0
@@ -21157,6 +21158,18 @@ MonoBehaviour:
   LastHandedness: 1
   LastScale: 1
   m_instanceId: 33892
+--- !u!114 &1786737529
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1786737526}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6cababbffd53bec479dc9d47daf0353c, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1 &1786831524
 GameObject:
   m_ObjectHideFlags: 0

--- a/package/com.unity.formats.usd/Tests/Editor/PackageUtilsTest.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/PackageUtilsTest.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using UnityEngine;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace Unity.Formats.USD.Tests
+{
+    class PackageUtilsTest
+    {
+        [Test, Description("Test getting a relative path from a base with no trailing slash")]
+        [UnityPlatform(exclude = new[]
+            {RuntimePlatform.WindowsEditor})] // URIs require a <drive>:\\ on Windows, see UriFormatException
+        public void TestRelativeFolderPathNoTrailingSlash()
+        {
+            var res = PackageUtils.GetRelativeFolderPath("/path/to/folder", "/path/to/folder/subfolder/file.ext");
+            Assert.That(res == "subfolder");
+        }
+
+        [Test, Description("Test getting a relative Windows path from a base with no trailing slash")]
+        public void TestRelativeFolderPathNoTrailingSlashWindows()
+        {
+            var res = PackageUtils.GetRelativeFolderPath("C:\\path\\to\\folder",
+                "C:\\path\\to\\folder\\subfolder\\file.ext");
+            Assert.That(res == "subfolder");
+        }
+
+        [Test, Description("Test getting a relative path from a base with a trailing slash")]
+        [UnityPlatform(exclude = new[]
+            {RuntimePlatform.WindowsEditor})] // URIs require a <drive>:\\ on Windows, see UriFormatException
+        public void TestRelativeFolderPathTrailingSlash()
+        {
+            var res = PackageUtils.GetRelativeFolderPath("/path/to/folder/", "/path/to/folder/subfolder/file.ext");
+            Assert.That(res == "subfolder");
+        }
+
+        [Test, Description("Test getting a relative Windows path from a base with a trailing slash")]
+        public void TestRelativeFolderPathTrailingSlashWindows()
+        {
+            var res = PackageUtils.GetRelativeFolderPath("C:\\path\\to\\folder\\",
+                "C:\\path\\to\\folder\\subfolder\\file.ext");
+            Assert.That(res == "subfolder");
+        }
+
+        [Test, Description("Test Unrelated paths")]
+        [UnityPlatform(exclude = new[]
+            {RuntimePlatform.WindowsEditor})] // URIs require a <drive>:\\ on Windows, see UriFormatException
+        public void TestUnrelatedPaths()
+        {
+            var res = PackageUtils.GetRelativeFolderPath("/another/path/to/folder/",
+                "/path/to/folder/subfolder/file.ext");
+            Assert.That(res == "../../../../path/to/folder/subfolder");
+        }
+
+        [Test, Description("Test Unrelated paths on Windows")]
+        public void TestUnrelatedPathsWindows()
+        {
+            const string folderPath = "D:\\path\\to\\folder\\subfolder";
+            var res = PackageUtils.GetRelativeFolderPath("C:\\path\\to\\folder\\", folderPath + "\\file.ext");
+            Assert.That(res == folderPath.Replace('\\', Path.DirectorySeparatorChar));
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Editor/PackageUtilsTest.cs.meta
+++ b/package/com.unity.formats.usd/Tests/Editor/PackageUtilsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 55ebf65f6978a4eeda8100cf270a4fd7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:**
2 issues were fixed : 
* USDU-65 : Samples were using hard coded paths that needed an easily forgettable manual update at each release. Impacted samples :  
** ImportMesh
** ImportMaterials
** UsdTimelinePlayable
* USDU-136 : A component used in the Samples scenes has been deprecated in 2019. and was throwing an error. Impacted samples:
** ImportMesh
** ImportMaterials
** ExportMesh
** HelloUSD4

## Testing

**Functional Testing status:**
In order to test the changes, you'll need a generated package. 
Then:
* load the package 
* import the samples.
=> Each sample should run with no error. 
ImportMesh and UsdTimelinePlayable should display some cubes and you should be able to see the valid path to Mesh.usd in the USD file field of the corresponding component.
ImportMaterials should display a cube with a butterfly texture.

## Overall Product Risks
No much, the samples are currently broken and they are accessories.

**Complexity:**
Minimal 

**Halo Effect:**
Minimal 

## Additional information

**Note to reviewers:**
I tried to find the sweet spot to allow the user experience to be intact (or sometimes improved) without doing overkilled fixes (those are samples, they are intended as illustration of what we can do, not as production-ready tools).

To fix the hard coded paths issue, GetCallerRelativeToProjectFolderPath was introduced, it allows to retrieve the path of the current script, that is then combined with the default file to use.

I also changed a little bit ImportMesh to allow the path to be changed (before in case of exception, the component was disabled but never re-enabled).

**I couldn't test on OSX but I can provide a package if it can help the testing**

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
- [x] Test on OSX
- [x] Test a build