### PR TITLE
Drop Unity 2018 support

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -2,13 +2,6 @@ test_editors:
   - version: trunk
   - version: 2020.1
   - version: 2019.4
-test_editors_old:  # Older Unity versions can't run test coverage.
-  - version: 2018.4
-test_editors_all:
-  - version: trunk
-  - version: 2020.1
-  - version: 2019.4
-  - version: 2018.4
 test_platforms:
   - name: win
     type: Unity::VM
@@ -54,26 +47,6 @@ test_{{ platform.name }}_{{ editor.version }}:
 {% endfor %}
 {% endfor %}
 
-# Don't run test coverage on Unity version older than 2019.2
-{% for editor in test_editors_old %}
-{% for platform in test_platforms %}
-test_{{ platform.name }}_{{ editor.version }}:
-  name : Test {{ editor.version }} on {{ platform.name }}
-  agent:
-    type: {{ platform.type }}
-    image: {{ platform.image }}
-    flavor: {{ platform.flavor}}
-  commands:
-      - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-      - upm-ci package test --unity-version {{ editor.version }} --package-path package/com.unity.formats.usd
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-  dependencies:
-    - .yamato/upm-ci.yml#pack
-{% endfor %}
-{% endfor %}
 
 test_trigger:
   name: Tests Trigger
@@ -85,7 +58,7 @@ test_trigger:
         - stable
   dependencies:
     - .yamato/upm-ci.yml#pack
-      {% for editor in test_editors_all %}
+      {% for editor in test_editors %}
       {% for platform in test_platforms %}
     - .yamato/upm-ci.yml#test_{{platform.name}}_{{editor.version}}
       {% endfor %}
@@ -101,12 +74,12 @@ nightly_test_trigger:
         frequency: daily
   dependencies:
     - .yamato/upm-ci.yml#pack
-      {% for editor in test_editors_all %}
+      {% for editor in test_editors %}
       {% for platform in test_platforms %}
     - .yamato/upm-ci.yml#test_{{platform.name}}_{{editor.version}}
       {% endfor %}
       {% endfor %}
-    
+
 run_preview_verified_staging:
   name: Preview and Verified Packages to Staging
   agent:
@@ -127,7 +100,7 @@ run_preview_verified_staging:
         - "upm-ci~/packages/**/*"
   dependencies:
     - .yamato/upm-ci.yml#pack
-      {% for editor in test_editors_all %}
+      {% for editor in test_editors %}
       {% for platform in test_platforms %}
     - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
       {% endfor %}

--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
@@ -62,13 +62,9 @@ namespace Unity.Formats.USD {
     }
 
     private GameObject GetPrefabObject(GameObject root) {
-#if UNITY_2017 || UNITY_2018_1 || UNITY_2018_2
-      return PrefabUtility.GetPrefabObject(root) as GameObject;
-#else
       // This is a great resource for determining object type, but only covers new APIs:
       // https://github.com/Unity-Technologies/UniteLA2018Examples/blob/master/Assets/Scripts/GameObjectTypeLogging.cs
       return PrefabUtility.GetCorrespondingObjectFromSource(root);
-#endif
     }
 
     private bool IsPrefabInstance(GameObject root) {
@@ -197,7 +193,7 @@ namespace Unity.Formats.USD {
               lastDir =  Path.GetDirectoryName(usdAsset.usdFullPath);
           string importFilepath = EditorUtility.OpenFilePanelWithFilters("Usd Asset", lastDir, new string[] { "Usd","us*"});
           if ( string.IsNullOrEmpty(importFilepath)) return;
-          usdAsset.usdFullPath = importFilepath;    
+          usdAsset.usdFullPath = importFilepath;
       }
       EditorGUILayout.EndHorizontal();
 
@@ -230,7 +226,7 @@ namespace Unity.Formats.USD {
       }
 
       var newOp = (LinearUnits)EditorGUILayout.EnumPopup("Original Scale", op);
-      
+
       if (newOp == LinearUnits.Custom) {
         // Force the UI to stay on the "custom" selection by adding an offset.
         float offset = op == newOp ? 0 : 0.01f;

--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
@@ -214,13 +214,9 @@ namespace Unity.Formats.USD {
     /// Returns the underlying prefab object, or null.
     /// </summary>
     private GameObject GetPrefabObject(GameObject root) {
-#if UNITY_2017 || UNITY_2018_1 || UNITY_2018_2
-      return UnityEditor.PrefabUtility.GetPrefabObject(root) as GameObject;
-#else
       // This is a great resource for determining object type, but only covers new APIs:
       // https://github.com/Unity-Technologies/UniteLA2018Examples/blob/master/Assets/Scripts/GameObjectTypeLogging.cs
       return UnityEditor.PrefabUtility.GetCorrespondingObjectFromSource(root);
-#endif
     }
 #endif
 
@@ -237,11 +233,6 @@ namespace Unity.Formats.USD {
     private string GetPrefabAssetPath(GameObject root) {
       string assetPath = null;
 #if UNITY_EDITOR
-// TODO: According to Yamato we don't support version of Unity earlier to this one. Is this really necessary?
-#if !UNITY_2018_3_OR_NEWER
-      assetPath = UnityEditor.AssetDatabase.GetAssetPath(
-              UnityEditor.PrefabUtility.GetPrefabObject(root));
-#else
       if (!UnityEditor.EditorUtility.IsPersistent(root)) {
         var prefabStage = UnityEditor.Experimental.SceneManagement.PrefabStageUtility.GetPrefabStage(root);
         if (prefabStage != null) {
@@ -256,7 +247,6 @@ namespace Unity.Formats.USD {
           }
         }
       }
-#endif
 #endif
       return assetPath;
     }

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
@@ -20,9 +20,7 @@ using UnityEngine.Profiling;
 using USD.NET;
 using USD.NET.Unity;
 
-#if UNITY_2018_1_OR_NEWER
 using Unity.Jobs;
-#endif
 using pxr;
 
 namespace Unity.Formats.USD {
@@ -52,17 +50,10 @@ namespace Unity.Formats.USD {
     }
 
     ReadAllJob<MeshSample> m_readMeshesJob;
-#if UNITY_2018_1_OR_NEWER
     public void BeginReading(Scene scene, PrimMap primMap) {
       m_readMeshesJob = new ReadAllJob<MeshSample>(scene, primMap.Meshes);
       m_readMeshesJob.Schedule(primMap.Meshes.Length, 2);
     }
-#else
-    public void BeginReading(Scene scene, PrimMap primMap) {
-      m_readMeshesJob = new ReadAllJob<MeshSample>(scene, primMap.Meshes);
-      m_readMeshesJob.Run();
-    }
-#endif
 
     public System.Collections.IEnumerator Import(Scene scene,
                              PrimMap primMap,
@@ -232,7 +223,7 @@ namespace Unity.Formats.USD {
       if (smr.sharedMesh == null) {
         smr.sharedMesh = new Mesh {name = UniqueMeshName(go.name)};
       }
-            
+
       // We only check if a mesh is dynamic when scene.IsPopulatingAccessMask is True. It only happens when a playable is
       // created, potentially way after mesh creation.
       if (isDynamic) {
@@ -256,7 +247,7 @@ namespace Unity.Formats.USD {
       if (mf.sharedMesh == null) {
         mf.sharedMesh = new Mesh {name = UniqueMeshName(go.name)};
       }
-      
+
       // We only check if a mesh is dynamic when scene.IsPopulatingAccessMask is True. It only happens when a playable is
       // created, potentially way after mesh creation.
       if (isDynamic) {
@@ -596,12 +587,6 @@ namespace Unity.Formats.USD {
 
 #if UNITY_EDITOR
       if (options.meshOptions.generateLightmapUVs) {
-#if !UNITY_2018_3_OR_NEWER
-        if (unityMesh.indexFormat == UnityEngine.Rendering.IndexFormat.UInt32) {
-          Debug.LogWarning("Skipping prim " + path + " due to large IndexFormat (UInt32) bug in older vesrsions of Unity");
-          return;
-        }
-#endif
         Profiler.BeginSample("Unwrap Lightmap UVs");
         var unwrapSettings = new UnityEditor.UnwrapParam();
 
@@ -719,7 +704,7 @@ namespace Unity.Formats.USD {
     /// (i.e. seams) will share UV values. This artifact will appear as seams on the object that
     /// would otherwise be seamless. The correct solution is to compare UV values at every vertex
     /// and un-weld vertices which do not share a common value.
-    /// 
+    ///
     /// Still, this approximation is useful since often values are only incorrect at the seam and
     /// for fast iteration loops, such a seam may be preferred over a long load time.
     /// </remarks>
@@ -870,11 +855,11 @@ namespace Unity.Formats.USD {
     }
 
     /// <summary>
-    /// Returns a unique mesh name by appending a short guid to the given string 
+    /// Returns a unique mesh name by appending a short guid to the given string
     /// </summary>
     private static string UniqueMeshName(string meshName) {
       var shortGuid = Convert.ToBase64String(Guid.NewGuid().ToByteArray());
-      return meshName + "_" +  shortGuid.Substring(0, shortGuid.Length-2); 
+      return meshName + "_" +  shortGuid.Substring(0, shortGuid.Length-2);
     }
   }
 }

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/ReadJob.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/ReadJob.cs
@@ -15,9 +15,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-#if !UNITY_2017
 using Unity.Jobs;
-#endif
 
 using pxr;
 using System.Collections;
@@ -33,16 +31,14 @@ namespace Unity.Formats.USD {
   /// <remarks>
   /// Internally the reads happen in a background thread while the main thread is unblocked to
   /// begin processing the data as it arrives.
-  /// 
+  ///
   /// Note because this class is templated on T, the static variables are unique to each
   /// instantiation of T; this is true regardless of whether or not the static uses type T.
   /// </remarks>
   public struct ReadAllJob<T> :
       IEnumerator<SampleEnumerator<T>.SampleHolder>,
-      IEnumerable<SampleEnumerator<T>.SampleHolder>
-#if !UNITY_2017
-      , IJobParallelFor
-#endif
+      IEnumerable<SampleEnumerator<T>.SampleHolder>,
+      IJobParallelFor
       where T : SampleBase, new() {
 
     static private Scene m_scene;

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Skel/SkeletonImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Skel/SkeletonImporter.cs
@@ -19,9 +19,7 @@ using UnityEngine;
 using USD.NET;
 using USD.NET.Unity;
 
-#if !UNITY_2017 && !UNITY_2018
 using Unity.Collections;
-#endif
 
 namespace Unity.Formats.USD {
 
@@ -162,7 +160,7 @@ namespace Unity.Formats.USD {
       }
 
       // TODO: Both indices and weights attributes can be animated. It's not handled yet.
-      // TODO: Having something that convert a UsdGeomPrimvar into a PrimvarSample could help simplify this code. 
+      // TODO: Having something that convert a UsdGeomPrimvar into a PrimvarSample could help simplify this code.
       int[] indices = IntrinsicTypeConverter.FromVtArray((VtIntArray)jointIndices.GetAttr().Get());
       int indicesElementSize = jointIndices.GetElementSize();
       pxr.TfToken indicesInterpolation = jointIndices.GetInterpolation();

--- a/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdPlayableTrack.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdPlayableTrack.cs
@@ -16,19 +16,14 @@ using UnityEngine.Timeline;
 
 namespace Unity.Formats.USD {
 
-#if UNITY_2017
-  [TrackMediaType(TimelineAsset.MediaType.Script)]
-#endif
   [TrackClipType(typeof(UsdPlayableAsset))]
   [TrackBindingType(typeof(UsdAsset))]
   [TrackColor(0.1f, 0.2f, 0.8f)]
   [System.Serializable]
   public class UsdPlayableTrack : TrackAsset {
-#if !UNITY_2018_1 && !UNITY_2017
     protected override void OnCreateClip(TimelineClip clip) {
       base.OnCreateClip(clip);
       clip.displayName = clip.asset.name;
     }
-#endif
   }
 }

--- a/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderTrack.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderTrack.cs
@@ -17,9 +17,6 @@ using UnityEngine.Timeline;
 namespace Unity.Formats.USD {
   [System.Serializable]
   [TrackClipType(typeof(UsdRecorderClip))]
-#if !UNITY_2018_2_OR_NEWER
-  [TrackMediaType(TimelineAsset.MediaType.Script)]
-#endif
   [TrackColor(0.7f, 0.0f, 0.0f)]
   public class UsdRecorderTrack : TrackAsset {
   }


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** https://jira.unity3d.com/browse/USDU-140

No need to support 2018 anymore. The code was peppered with ifdefs for old Unity so this PR cleans it up.


## Testing

**Functional Testing status:**

Ran the tests, tried loading the prefabs and using the timeline. All seems ok.

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
Minimal

**Halo Effect:**
Minimal

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
