### PR TITLE
Add EditorPrefs for payload policy and material import mode

### DIFF
--- a/package/com.unity.formats.usd/CHANGELOG.md
+++ b/package/com.unity.formats.usd/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased] - 2020-10-27
 ### Changed
+- PayloadPolicy and MaterialImportMode are now Editor Preferences that can be changed in the USD/Preferences menu.
+- PayloadPolicy now defaults to LoadAll in Editor
+- MaterialImportMode now defaults to PreviewSurface in Editor
 - Set material name in Unity to match the material name in the USD file on import.
 
 ### Bug Fixes

--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdMenu.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdMenu.cs
@@ -12,22 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.IO;
 using System.Linq;
 using UnityEngine;
 using UnityEditor;
 using USD.NET;
 using USD.NET.Unity;
+using Object = UnityEngine.Object;
 
 namespace Unity.Formats.USD {
 
-  public class UsdMenu : MonoBehaviour
+  public static class UsdMenu
   {
-      const string PayloadPolicyPrefName = "USD.LoadAllPayloads";
-      const string MaterialPolicyPrefName = "USD.LoadPreviewSurface";
+    const string PayloadPolicyPrefName = "USD.LoadAllPayloads";
+    const string MaterialPolicyPrefName = "USD.LoadPreviewSurface";
 
-      const string UsdPrefPayloadMenuName = "USD/Preferences/Load all payloads";
-      const string UsdPrefMaterialMenuName = "USD/Preferences/Load preview surface";
+    const string UsdPrefPayloadMenuName = "USD/Preferences/Load all payloads";
+    const string UsdPrefMaterialMenuName = "USD/Preferences/Load preview surface";
+
+    static SavedBool loadAllPayloads = new SavedBool(PayloadPolicyPrefName, true);
+    static SavedBool loadPreviewSurface = new SavedBool(MaterialPolicyPrefName, false);
 
     public static Scene InitForSave(string defaultName, string fileExtension = "usd,usda,usdc") {
       var filePath = EditorUtility.SaveFilePanel("Export USD File", "", defaultName, fileExtension);
@@ -203,33 +208,27 @@ namespace Unity.Formats.USD {
 
 
     [MenuItem(UsdPrefPayloadMenuName, priority = 0)]
-    static void LoadAllPayloads()
-    {
-        var enabled = Menu.GetChecked(UsdPrefPayloadMenuName);
-        EditorPrefs.SetBool(PayloadPolicyPrefName, !enabled);
-        Menu.SetChecked(UsdPrefPayloadMenuName, !enabled);
+    static void LoadAllPayloads() {
+      loadAllPayloads.value = !Menu.GetChecked(UsdPrefPayloadMenuName);
+      Menu.SetChecked(UsdPrefPayloadMenuName, loadAllPayloads);
     }
 
     [MenuItem(UsdPrefPayloadMenuName, true)]
     static bool LoadAllPayloadsValidate() {
-        var enabled = EditorPrefs.GetBool(PayloadPolicyPrefName, true);
-        Menu.SetChecked(UsdPrefPayloadMenuName, enabled);
-        return true;
+      Menu.SetChecked(UsdPrefPayloadMenuName, loadAllPayloads);
+      return true;
     }
 
     [MenuItem(UsdPrefMaterialMenuName, priority = 0)]
-    static void LoadAllPreviewSurface()
-    {
-        var enabled = Menu.GetChecked(UsdPrefMaterialMenuName);
-        EditorPrefs.SetBool(MaterialPolicyPrefName, !enabled);
-        Menu.SetChecked(UsdPrefMaterialMenuName, !enabled);
+    static void LoadAllPreviewSurface() {
+      loadPreviewSurface.value = !Menu.GetChecked(UsdPrefMaterialMenuName);
+      Menu.SetChecked(UsdPrefMaterialMenuName, loadPreviewSurface);
     }
 
     [MenuItem(UsdPrefMaterialMenuName, true)]
     static bool LoadAllPreviewSurfaceValidate() {
-        var enabled = EditorPrefs.GetBool(MaterialPolicyPrefName, false);
-        Menu.SetChecked(UsdPrefMaterialMenuName, enabled);
-        return true;
+      Menu.SetChecked(UsdPrefMaterialMenuName, loadPreviewSurface);
+      return true;
     }
 
     [MenuItem("USD/Import as GameObjects", priority = 20)]

--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdMenu.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdMenu.cs
@@ -28,8 +28,8 @@ namespace Unity.Formats.USD {
     const string PayloadPolicyPrefName = "USD.LoadAllPayloads";
     const string MaterialPolicyPrefName = "USD.LoadPreviewSurface";
 
-    const string UsdPrefPayloadMenuName = "USD/Preferences/Load all payloads";
-    const string UsdPrefMaterialMenuName = "USD/Preferences/Load preview surface";
+    const string UsdPrefPayloadMenuName = "USD/Preferences/Load All Payloads";
+    const string UsdPrefMaterialMenuName = "USD/Preferences/Load Preview Surface";
 
     static SavedBool loadAllPayloads = new SavedBool(PayloadPolicyPrefName, true);
     static SavedBool loadPreviewSurface = new SavedBool(MaterialPolicyPrefName, false);

--- a/package/com.unity.formats.usd/Editor/Scripts/Preferences/SavedBool.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Preferences/SavedBool.cs
@@ -2,7 +2,7 @@
 
 namespace Unity.Formats.USD
 {
-    class SavedBool
+    public class SavedBool
     {
         bool m_Value;
         string m_Name;

--- a/package/com.unity.formats.usd/Editor/Scripts/Preferences/SavedBool.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Preferences/SavedBool.cs
@@ -1,0 +1,42 @@
+﻿using UnityEditor;
+
+namespace Unity.Formats.USD
+{
+    class SavedBool
+    {
+        bool m_Value;
+        string m_Name;
+        bool m_Loaded;
+        public SavedBool(string name, bool value)
+        {
+            m_Name = name;
+            m_Loaded = false;
+            m_Value = value;
+        }
+
+        private void Load()
+        {
+            if (m_Loaded)
+                return;
+            m_Loaded = true;
+            m_Value = EditorPrefs.GetBool(m_Name, m_Value);
+        }
+
+        public bool value
+        {
+            get { Load(); return m_Value; }
+            set
+            {
+                Load();
+                if (m_Value == value)
+                    return;
+                m_Value = value;
+                EditorPrefs.SetBool(m_Name, value);
+            }
+        }
+        public static implicit operator bool(SavedBool s)
+        {
+            return s.value;
+        }
+    }
+}


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** https://jira.unity3d.com/browse/USDU-141

Default values for the UsdAsset were set to not load the payloads and not load the materials. It gives the feeling the importer is broken and it's not clear to a new user which option needs to be changed to load the full asset.

This PR changes the default values  to load the payloads and the materials, and adds those settings as EditorPrefs. 
The settings are accessible in the USD/Preferences sub menu

![usd_prefs_menu](https://user-images.githubusercontent.com/2866068/100394589-ac64e900-300b-11eb-984d-f9bcb6ef8091.png)

Note that the default values of the UsdAsset component were not changed but the user have full control over them.



## Testing

**Functional Testing status:**

Loading the usd kitchen shows that the payload policy is respected
Loading the usd female skeleton show that the material import mode is respected
Restarting Unity after changing the prefs shows that the prefs are registered
I also checked that the prefs were properly set in the windows registry

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
Minimal

**Halo Effect:**
Minimal

## Additional information

**Note to reviewers:**

I also reformated the code to respect Unity code style. I'll do that progressively on all files I modify.
The functional changes are in the first commit.

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
