### PR TITLE
CI: Allow true isolation

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,6 +1,7 @@
 test_editors:
   - version: trunk
-  - version: 2020.1
+  - version: 2020.2
+  - version: 2021.1
   - version: 2019.4
 test_platforms:
   - name: win

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -37,7 +37,7 @@ test_{{ platform.name }}_{{ editor.version }}:
   commands:
       - npm install upm-ci-utils@latest -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
       - upm-ci package test --unity-version {{ editor.version }} --package-path package/com.unity.formats.usd
-        --enable-code-coverage --code-coverage-options 'enableCyclomaticComplexity;generateHtmlReport'
+        --enable-code-coverage --code-coverage-options 'enableCyclomaticComplexity;generateHtmlReport' --extra-create-project-arg="-upmNoDefaultPackages"
   artifacts:
     logs:
       paths:

--- a/package/com.unity.formats.usd/package.json
+++ b/package/com.unity.formats.usd/package.json
@@ -1,7 +1,8 @@
 {
     "dependencies": {
         "com.unity.timeline" : "1.0.0",
-        "com.unity.modules.screencapture": "1.0.0"
+        "com.unity.modules.screencapture": "1.0.0",
+        "com.unity.modules.physics": "1.0.0"
     },
     "description": "The Unity USD package contains a set of libraries designed to support the use of Pixar's Universal Scene Description (USD) in Unity. The goal of this package is to make it maximally easy to integrate USD using native Unity & C# data types with a familiar serialization paradigm and little prior knowledge of USD. USD enables round-trip asset workflows between digital content creation tools like Maya, 3ds Max, Houdini, Katana, Nuke, Modo, Sketchup, Substance Designer, and Substance Painter. \n\nUnlike other asset file formats, Universal Scene Description is designed to support an entire asset pipeline and to enable teams to work in parallel using asset references and overrides. \n\nThis package includes ready-to-use binaries and examples to allow anyone to easily jump-in.\n\nUSD version: 20.08",
     "displayName": "USD",

--- a/package/com.unity.formats.usd/package.json
+++ b/package/com.unity.formats.usd/package.json
@@ -1,6 +1,7 @@
 {
     "dependencies": {
-        "com.unity.timeline" : "1.0.0"
+        "com.unity.timeline" : "1.0.0",
+        "com.unity.modules.screencapture": "1.0.0"
     },
     "description": "The Unity USD package contains a set of libraries designed to support the use of Pixar's Universal Scene Description (USD) in Unity. The goal of this package is to make it maximally easy to integrate USD using native Unity & C# data types with a familiar serialization paradigm and little prior knowledge of USD. USD enables round-trip asset workflows between digital content creation tools like Maya, 3ds Max, Houdini, Katana, Nuke, Modo, Sketchup, Substance Designer, and Substance Painter. \n\nUnlike other asset file formats, Universal Scene Description is designed to support an entire asset pipeline and to enable teams to work in parallel using asset references and overrides. \n\nThis package includes ready-to-use binaries and examples to allow anyone to easily jump-in.\n\nUSD version: 20.08",
     "displayName": "USD",


### PR DESCRIPTION
## Purpose of this PR

Added the option to test the isolation + 2 missing dependencies.
2019.4 and 2020.2 are still failing because of Timeline dependencies not yet adapted to true isolation.
Will ask what is the timeframe to fix previous versions.

We could also update our timeline dependency (trunk and 2021.1 are using 1.5.1-pre.3).
I double checked, CI is back to green when doing so.

While I was there I updated the Unity test versions.

**Complexity:**
Minimal 

**Halo Effect:**
Minimal 

