### PR TITLE
Fix hardcoded package name in InitUSD (USDU-48)

### DIFF
--- a/package/com.unity.formats.usd/Runtime/InitUsd.cs
+++ b/package/com.unity.formats.usd/Runtime/InitUsd.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using USD.NET;
 using USD.NET.Unity;
@@ -64,12 +65,11 @@ namespace Unity.Formats.USD
         // USD has several auxillary C++ plugin discovery files which must be discoverable at run-time
         // We store those libs in Support/ThirdParty/Usd and then set a magic environment variable to let
         // USD's libPlug know where to look to find them.
-        private static void SetupUsdPath()
+        private static void SetupUsdPath([CallerFilePath] string sourceFilePath = "")
         {
 #if UNITY_EDITOR
-            // TODO: this is not robust, e.g. if anyone changes CWD from the default, package resolution
-            // will fail. Following up with UPM devs to see what we can do about it.
-            var supPath = System.IO.Path.GetFullPath("Packages/com.unity.formats.usd/Runtime/Plugins");
+            var fileInfo = new System.IO.FileInfo(sourceFilePath);
+            var supPath = System.IO.Path.Combine(fileInfo.DirectoryName, "Plugins");
 #else
       var supPath = UnityEngine.Application.dataPath.Replace("\\", "/") + "/Plugins";
 #endif


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** https://jira.unity3d.com/browse/USDU-48

Fix the hardcoded package name in InitUSD. It can be problematic for third party developers who publish custom versions of the package in their own registry with a different scope.


## Testing

**Functional Testing status:**

Tested by renaming the package name locally.

**Performance Testing status:**

NA

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
Minimal

**Halo Effect:**
Minimal

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
