### PR TITLE
#USDU-155 Create import/export helpers to clean the UsdMenu 

### DIFF
--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
@@ -221,7 +221,10 @@ namespace Unity.Formats.USD
 
             EditorGUILayout.BeginHorizontal();
             EditorGUILayout.PrefixLabel("USD File");
-            usdAsset.usdFullPath = EditorGUILayout.TextField(usdAsset.usdFullPath, EditorStyles.textField);
+            GUI.enabled = false;
+            EditorGUILayout.TextField(usdAsset.usdFullPath, EditorStyles.textField);
+            GUI.enabled = true;
+
             if (GUILayout.Button("..."))
             {
                 string lastDir;

--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdMenu.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdMenu.cs
@@ -21,7 +21,7 @@ using USD.NET.Unity;
 
 namespace Unity.Formats.USD
 {
-    public class UsdMenu
+    public static class UsdMenu
     {
         [MenuItem("USD/Export Selected with Children", true)]
         static bool EnableMenuExportSelectedWithChildren()
@@ -32,7 +32,10 @@ namespace Unity.Formats.USD
         [MenuItem("USD/Export Selected with Children", priority = 50)]
         static void MenuExportSelectedWithChildren()
         {
-            ExportHelpers.ExportSelected(BasisTransformation.SlowAndSafe);
+            var go = Selection.gameObjects.First();
+            var filePath = EditorUtility.SaveFilePanel("Export USD File", "", go.name, "usd,usda,usdc");
+            var scene = ExportHelpers.InitForSave(filePath);
+            ExportHelpers.ExportGameObjects(Selection.gameObjects, scene,BasisTransformation.SlowAndSafe);
         }
 
         [MenuItem("USD/Export Transform Overrides", true)]
@@ -45,7 +48,8 @@ namespace Unity.Formats.USD
         static public void MenuExportTransforms()
         {
             var root = Selection.activeGameObject.GetComponentInParent<UsdAsset>();
-            var overs = ExportHelpers.InitForSave(Path.GetFileNameWithoutExtension(root.usdFullPath) + "_overs");
+            var filePath = EditorUtility.SaveFilePanel("Export USD File", "", Path.GetFileNameWithoutExtension(root.usdFullPath) + "_overs", "usd,usda,usdc");
+            var overs = ExportHelpers.InitForSave(filePath);
             root.ExportOverrides(overs);
         }
 

--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdMenu.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdMenu.cs
@@ -139,7 +139,7 @@ namespace Unity.Formats.USD
                 return;
             }
 
-            ImportHelpers.ImportSceneAsGameObject(scene);
+            ImportHelpers.ImportSceneAsGameObject(scene, Selection.activeGameObject);
             scene.Close();
         }
 

--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdMenu.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdMenu.cs
@@ -21,50 +21,8 @@ using USD.NET.Unity;
 
 namespace Unity.Formats.USD
 {
-    public class UsdMenu : MonoBehaviour
+    public class UsdMenu
     {
-        public static Scene InitForSave(string defaultName, string fileExtension = "usd,usda,usdc")
-        {
-            var filePath = EditorUtility.SaveFilePanel("Export USD File", "", defaultName, fileExtension);
-
-            if (filePath == null || filePath.Length == 0)
-            {
-                return null;
-            }
-
-            var fileDir = Path.GetDirectoryName(filePath);
-
-            if (!Directory.Exists(fileDir))
-            {
-                var di = Directory.CreateDirectory(fileDir);
-                if (!di.Exists)
-                {
-                    Debug.LogError("Failed to create directory: " + fileDir);
-                    return null;
-                }
-            }
-
-            InitUsd.Initialize();
-            var scene = Scene.Create(filePath);
-            scene.Time = 0;
-            scene.StartTime = 0;
-            scene.EndTime = 0;
-            return scene;
-        }
-
-        public static Scene InitForOpen()
-        {
-            string path = EditorUtility.OpenFilePanel("Import USD File", "", "usd,usda,usdc,abc");
-            if (path == null || path.Length == 0)
-            {
-                return null;
-            }
-
-            InitUsd.Initialize();
-            var stage = pxr.UsdStage.Open(path, pxr.UsdStage.InitialLoadSet.LoadNone);
-            return Scene.Open(stage);
-        }
-
         [MenuItem("USD/Export Selected with Children", true)]
         static bool EnableMenuExportSelectedWithChildren()
         {
@@ -74,7 +32,7 @@ namespace Unity.Formats.USD
         [MenuItem("USD/Export Selected with Children", priority = 50)]
         static void MenuExportSelectedWithChildren()
         {
-            ExportSelected(BasisTransformation.SlowAndSafe);
+            ExportHelpers.ExportSelected(BasisTransformation.SlowAndSafe);
         }
 
         [MenuItem("USD/Export Transform Overrides", true)]
@@ -87,7 +45,7 @@ namespace Unity.Formats.USD
         static public void MenuExportTransforms()
         {
             var root = Selection.activeGameObject.GetComponentInParent<UsdAsset>();
-            var overs = InitForSave(Path.GetFileNameWithoutExtension(root.usdFullPath) + "_overs");
+            var overs = ExportHelpers.InitForSave(Path.GetFileNameWithoutExtension(root.usdFullPath) + "_overs");
             root.ExportOverrides(overs);
         }
 
@@ -167,188 +125,42 @@ namespace Unity.Formats.USD
     }
 #endif
 
-        static private pxr.SdfPath GetDefaultRoot(Scene scene)
-        {
-            // We can't safely assume the default prim is the model root, because Alembic files will
-            // always have a default prim set arbitrarily.
-
-            // If there is only one root prim, reference this prim.
-            var children = scene.Stage.GetPseudoRoot().GetChildren().ToList();
-            if (children.Count == 1)
-            {
-                return children[0].GetPath();
-            }
-
-            // Otherwise there are 0 or many root prims, in this case the best option is to reference
-            // them all, to avoid confusion.
-            return pxr.SdfPath.AbsoluteRootPath();
-        }
-
-        static void ExportSelected(BasisTransformation basisTransform,
-            string fileExtension = "usd,usda,usdc",
-            bool exportMonoBehaviours = false)
-        {
-            Scene scene = null;
-
-            foreach (GameObject go in Selection.gameObjects)
-            {
-                if (scene == null)
-                {
-                    scene = InitForSave(go.name, fileExtension);
-                    if (scene == null)
-                    {
-                        return;
-                    }
-                }
-
-                try
-                {
-                    SceneExporter.Export(go, scene, basisTransform,
-                        exportUnvarying: true, zeroRootTransform: false,
-                        exportMonoBehaviours: exportMonoBehaviours);
-                }
-                catch (System.Exception ex)
-                {
-                    Debug.LogException(ex);
-                    continue;
-                }
-            }
-
-            if (scene != null)
-            {
-                scene.Save();
-                scene.Close();
-            }
-        }
 
         [MenuItem("USD/Import as GameObjects", priority = 0)]
         public static void MenuImportAsGameObjects()
         {
-            var scene = InitForOpen();
+            var scene = ImportHelpers.InitForOpen();
             if (scene == null)
             {
                 return;
             }
 
-            ImportSceneAsGameObject(scene);
+            ImportHelpers.ImportSceneAsGameObject(scene);
             scene.Close();
-        }
-
-        public static GameObject ImportSceneAsGameObject(Scene scene, SceneImportOptions importOptions = null)
-        {
-            string path = scene.FilePath;
-
-            // Time-varying data is not supported and often scenes are written without "Default" time
-            // values, which makes setting an arbitrary time safer (because if only default was authored
-            // the time will be ignored and values will resolve to default time automatically).
-            scene.Time = 1.0;
-
-            if (importOptions == null)
-            {
-                importOptions = new SceneImportOptions();
-                importOptions.changeHandedness = BasisTransformation.SlowAndSafe;
-                importOptions.materialImportMode = MaterialImportMode.ImportDisplayColor;
-                importOptions.usdRootPath = GetDefaultRoot(scene);
-            }
-
-            GameObject root = new GameObject(GetObjectName(importOptions.usdRootPath, path));
-
-            if (Selection.gameObjects.Length > 0)
-            {
-                root.transform.SetParent(Selection.gameObjects[0].transform);
-            }
-
-            try
-            {
-                UsdToGameObject(root, scene, importOptions);
-                return root;
-            }
-            catch (SceneImporter.ImportException)
-            {
-                GameObject.DestroyImmediate(root);
-                return null;
-            }
         }
 
         [MenuItem("USD/Import as Prefab", priority = 1)]
         public static void MenuImportAsPrefab()
         {
-            var scene = InitForOpen();
+            var scene = ImportHelpers.InitForOpen();
             if (scene == null)
             {
                 return;
             }
 
-            string path = scene.FilePath;
-
-            // Time-varying data is not supported and often scenes are written without "Default" time
-            // values, which makes setting an arbitrary time safer (because if only default was authored
-            // the time will be ignored and values will resolve to default time automatically).
-            scene.Time = 1.0;
-
-            var importOptions = new SceneImportOptions();
-            importOptions.projectAssetPath = GetSelectedAssetPath();
-            importOptions.changeHandedness = BasisTransformation.SlowAndSafe;
-            importOptions.materialImportMode = MaterialImportMode.ImportDisplayColor;
-            importOptions.usdRootPath = GetDefaultRoot(scene);
-
-            var invalidChars = Path.GetInvalidFileNameChars();
-            var prefabName = string.Join("_", GetPrefabName(path).Split(invalidChars,
-                System.StringSplitOptions.RemoveEmptyEntries)).TrimEnd('.');
-            string prefabPath = importOptions.projectAssetPath + prefabName + ".prefab";
-            prefabPath = AssetDatabase.GenerateUniqueAssetPath(prefabPath);
-            string clipName = Path.GetFileNameWithoutExtension(path);
-
-            var go = new GameObject(GetObjectName(importOptions.usdRootPath, path));
-            try
-            {
-                UsdToGameObject(go, scene, importOptions);
-                SceneImporter.SavePrefab(go, prefabPath, clipName, importOptions);
-            }
-            finally
-            {
-                GameObject.DestroyImmediate(go);
-                scene.Close();
-            }
+            ImportHelpers.ImportAsPrefab(scene);
         }
 
         [MenuItem("USD/Import as Timeline Clip", priority = 2)]
         public static void MenuImportAsTimelineClip()
         {
-            var scene = InitForOpen();
+            var scene = ImportHelpers.InitForOpen();
             if (scene == null)
             {
                 return;
             }
 
-            string path = scene.FilePath;
-
-            var invalidChars = Path.GetInvalidFileNameChars();
-            var prefabName = string.Join("_", GetPrefabName(path).Split(invalidChars,
-                System.StringSplitOptions.RemoveEmptyEntries)).TrimEnd('.');
-
-            string prefabPath = GetSelectedAssetPath() + prefabName + ".prefab";
-            prefabPath = AssetDatabase.GenerateUniqueAssetPath(prefabPath);
-            string clipName = Path.GetFileNameWithoutExtension(path);
-
-            var importOptions = new SceneImportOptions();
-            importOptions.projectAssetPath = GetSelectedAssetPath();
-            importOptions.changeHandedness = BasisTransformation.FastWithNegativeScale;
-            importOptions.materialImportMode = MaterialImportMode.ImportDisplayColor;
-            importOptions.usdRootPath = GetDefaultRoot(scene);
-
-            var go = new GameObject(GetObjectName(importOptions.usdRootPath, path));
-
-            try
-            {
-                // Ensure we have at least one GameObject with the import settings.
-                XformImporter.BuildSceneRoot(scene, go.transform, importOptions);
-                SceneImporter.SavePrefab(go, prefabPath, clipName, importOptions);
-            }
-            finally
-            {
-                GameObject.DestroyImmediate(go);
-            }
+            ImportHelpers.ImportAsTimelineClip(scene);
         }
 
         [MenuItem("USD/Unload Subtree", true)]
@@ -417,70 +229,6 @@ namespace Unity.Formats.USD
                 Debug.LogWarning("No USD payloads found in subtree.");
                 return;
             }
-        }
-
-        /// <summary>
-        /// Returns the selected object path or "Assets/" if no object is selected.
-        /// </summary>
-        public static string GetSelectedAssetPath()
-        {
-            Object[] selectedAsset = Selection.GetFiltered(typeof(Object), SelectionMode.Assets);
-            foreach (Object obj in selectedAsset)
-            {
-                var path = AssetDatabase.GetAssetPath(obj.GetInstanceID());
-                if (string.IsNullOrEmpty(path))
-                {
-                    continue;
-                }
-
-                if (File.Exists(path))
-                {
-                    path = Path.GetDirectoryName(path);
-                }
-
-                if (!path.EndsWith("/"))
-                {
-                    path += "/";
-                }
-
-                return path;
-            }
-
-            return "Assets/";
-        }
-
-        public static GameObject UsdToGameObject(GameObject parent,
-            Scene scene,
-            SceneImportOptions importOptions)
-        {
-            try
-            {
-                SceneImporter.ImportUsd(parent, scene, new PrimMap(), importOptions);
-            }
-            finally
-            {
-                scene.Close();
-            }
-
-            return parent;
-        }
-
-        private static string GetObjectName(pxr.SdfPath rootPrimName, string path)
-        {
-            return pxr.UsdCs.TfIsValidIdentifier(rootPrimName.GetName())
-                ? rootPrimName.GetName()
-                : GetObjectName(path);
-        }
-
-        private static string GetObjectName(string path)
-        {
-            return UnityTypeConverter.MakeValidIdentifier(Path.GetFileNameWithoutExtension(path));
-        }
-
-        private static string GetPrefabName(string path)
-        {
-            var fileName = GetObjectName(path);
-            return fileName + "_prefab";
         }
     }
 }

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/ExportHelpers.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/ExportHelpers.cs
@@ -1,0 +1,78 @@
+﻿using System.IO;
+using UnityEditor;
+using UnityEngine;
+using USD.NET;
+
+namespace Unity.Formats.USD
+{
+    public static class ExportHelpers
+    {
+#if UNITY_EDITOR
+        public static Scene InitForSave(string defaultName, string fileExtension = "usd,usda,usdc")
+        {
+            var filePath = EditorUtility.SaveFilePanel("Export USD File", "", defaultName, fileExtension);
+
+            if (filePath == null || filePath.Length == 0)
+            {
+                return null;
+            }
+
+            var fileDir = Path.GetDirectoryName(filePath);
+
+            if (!Directory.Exists(fileDir))
+            {
+                var di = Directory.CreateDirectory(fileDir);
+                if (!di.Exists)
+                {
+                    Debug.LogError("Failed to create directory: " + fileDir);
+                    return null;
+                }
+            }
+
+            InitUsd.Initialize();
+            var scene = Scene.Create(filePath);
+            scene.Time = 0;
+            scene.StartTime = 0;
+            scene.EndTime = 0;
+            return scene;
+        }
+#endif
+
+        public static void ExportSelected(BasisTransformation basisTransform,
+            string fileExtension = "usd,usda,usdc",
+            bool exportMonoBehaviours = false)
+        {
+            Scene scene = null;
+
+            foreach (GameObject go in Selection.gameObjects)
+            {
+                if (scene == null)
+                {
+                    scene = InitForSave(go.name, fileExtension);
+                    if (scene == null)
+                    {
+                        return;
+                    }
+                }
+
+                try
+                {
+                    SceneExporter.Export(go, scene, basisTransform,
+                        exportUnvarying: true, zeroRootTransform: false,
+                        exportMonoBehaviours: exportMonoBehaviours);
+                }
+                catch (System.Exception ex)
+                {
+                    Debug.LogException(ex);
+                    continue;
+                }
+            }
+
+            if (scene != null)
+            {
+                scene.Save();
+                scene.Close();
+            }
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/ExportHelpers.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/ExportHelpers.cs
@@ -7,12 +7,9 @@ namespace Unity.Formats.USD
 {
     public static class ExportHelpers
     {
-#if UNITY_EDITOR
-        public static Scene InitForSave(string defaultName, string fileExtension = "usd,usda,usdc")
+        public static Scene InitForSave(string filePath)
         {
-            var filePath = EditorUtility.SaveFilePanel("Export USD File", "", defaultName, fileExtension);
-
-            if (filePath == null || filePath.Length == 0)
+            if (string.IsNullOrEmpty(filePath))
             {
                 return null;
             }
@@ -36,25 +33,15 @@ namespace Unity.Formats.USD
             scene.EndTime = 0;
             return scene;
         }
-#endif
 
-        public static void ExportSelected(BasisTransformation basisTransform,
-            string fileExtension = "usd,usda,usdc",
-            bool exportMonoBehaviours = false)
+        public static void ExportGameObjects(GameObject[] objects, Scene scene, BasisTransformation basisTransform,
+                                          bool exportMonoBehaviours = false)
         {
-            Scene scene = null;
+            if (scene == null)
+                return;
 
-            foreach (GameObject go in Selection.gameObjects)
+            foreach (GameObject go in objects)
             {
-                if (scene == null)
-                {
-                    scene = InitForSave(go.name, fileExtension);
-                    if (scene == null)
-                    {
-                        return;
-                    }
-                }
-
                 try
                 {
                     SceneExporter.Export(go, scene, basisTransform,
@@ -64,15 +51,10 @@ namespace Unity.Formats.USD
                 catch (System.Exception ex)
                 {
                     Debug.LogException(ex);
-                    continue;
                 }
             }
-
-            if (scene != null)
-            {
-                scene.Save();
-                scene.Close();
-            }
+            scene.Save();
+            scene.Close();
         }
     }
 }

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/ExportHelpers.cs.meta
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/ExportHelpers.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ff4b0fbbfd3e41f782b9e9f03f813653
+timeCreated: 1613596650

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/ImportHelpers.cs.meta
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/ImportHelpers.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5e226d4ad64f4497ab11ca8ff7ec3e54
+timeCreated: 1613595700

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/UsdzExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/UsdzExporter.cs
@@ -46,7 +46,7 @@ namespace Unity.Formats.USD
                 Directory.SetCurrentDirectory(tmpDirPath);
 
                 // Create the tmp .usd scene, into which the data will be exported.
-                Scene scene = InitForSave(usdcFileName);
+                Scene scene = ExportHelpers.InitForSave(Path.Combine(tmpDirPath,usdcFileName));
                 Vector3 localScale = root.transform.localScale;
 
                 try
@@ -90,28 +90,6 @@ namespace Unity.Formats.USD
                 Directory.SetCurrentDirectory(currentDir);
                 tmpDir.Delete(recursive: true);
             }
-        }
-
-        internal static Scene InitForSave(string filePath)
-        {
-            string fileDir = Path.GetDirectoryName(filePath);
-
-            if (!string.IsNullOrEmpty(fileDir) && !Directory.Exists(fileDir))
-            {
-                var di = Directory.CreateDirectory(fileDir);
-                if (!di.Exists)
-                {
-                    Debug.LogError("Failed to create directory: " + fileDir);
-                    return null;
-                }
-            }
-
-            InitUsd.Initialize();
-            Scene scene = Scene.Create(filePath);
-            scene.Time = 0;
-            scene.StartTime = 0;
-            scene.EndTime = 0;
-            return scene;
         }
     }
 }

--- a/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Timeline/UsdRecorderBehaviour.cs
@@ -82,7 +82,7 @@ namespace Unity.Formats.USD
                     // Set the current working directory to the tmp directory to export with relative paths.
                     Directory.SetCurrentDirectory(tmpDirPath);
 
-                    Clip.UsdScene = UsdzExporter.InitForSave(usdcFileName);
+                    Clip.UsdScene = ExportHelpers.InitForSave(Path.Combine(tmpDirPath,usdcFileName));
                 }
                 else
                 {

--- a/package/com.unity.formats.usd/Tests/Editor/BaseFixture.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/BaseFixture.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using UnityEditor;
+using Scene = USD.NET.Scene;
+
+namespace Unity.Formats.USD.Tests
+{
+    public class BaseFixtureEditor : BaseFixture
+    {
+        readonly public List<string> m_assetsToDelete = new List<string>();
+
+
+        [TearDown]
+        public void DeleteAssetsFiles()
+        {
+            foreach (var file in m_assetsToDelete)
+            {
+                AssetDatabase.DeleteAsset(file);
+            }
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Editor/BaseFixture.cs.meta
+++ b/package/com.unity.formats.usd/Tests/Editor/BaseFixture.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0f03ea67818747198d5ce9f9aed1974a
+timeCreated: 1614199416

--- a/package/com.unity.formats.usd/Tests/Editor/EditorTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/EditorTests.cs
@@ -19,7 +19,7 @@ namespace Unity.Formats.USD.Tests
             var usdPath = Path.GetFullPath(AssetDatabase.GUIDToAssetPath(m_usdGUID));
             var stage = pxr.UsdStage.Open(usdPath, pxr.UsdStage.InitialLoadSet.LoadNone);
             var scene = Scene.Open(stage);
-            m_usdRoot = USD.UsdMenu.ImportSceneAsGameObject(scene);
+            m_usdRoot = ImportHelpers.ImportSceneAsGameObject(scene);
             scene.Close();
         }
 
@@ -73,7 +73,7 @@ namespace Unity.Formats.USD.Tests
             var scene = Scene.Open(stage);
             var importOptions = new SceneImportOptions();
             importOptions.materialImportMode = MaterialImportMode.ImportPreviewSurface;
-            m_usdRoot = USD.UsdMenu.ImportSceneAsGameObject(scene, importOptions);
+            m_usdRoot = ImportHelpers.ImportSceneAsGameObject(scene, importOptions);
             scene.Close();
         }
 

--- a/package/com.unity.formats.usd/Tests/Editor/EditorTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/EditorTests.cs
@@ -73,7 +73,7 @@ namespace Unity.Formats.USD.Tests
             var scene = Scene.Open(stage);
             var importOptions = new SceneImportOptions();
             importOptions.materialImportMode = MaterialImportMode.ImportPreviewSurface;
-            m_usdRoot = ImportHelpers.ImportSceneAsGameObject(scene, importOptions);
+            m_usdRoot = ImportHelpers.ImportSceneAsGameObject(scene, importOptions: importOptions);
             scene.Close();
         }
 

--- a/package/com.unity.formats.usd/Tests/Editor/FBXHandednessModeTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/FBXHandednessModeTests.cs
@@ -45,7 +45,7 @@ namespace Unity.Formats.USD.Tests
             importOptions.changeHandedness = changeHandedness;
             importOptions.scale = 0.01f;
             importOptions.materialImportMode = MaterialImportMode.ImportDisplayColor;
-            var usdRoot = ImportHelpers.ImportSceneAsGameObject(scene, importOptions);
+            var usdRoot = ImportHelpers.ImportSceneAsGameObject(scene, importOptions: importOptions);
             scene.Close();
             return usdRoot;
         }

--- a/package/com.unity.formats.usd/Tests/Editor/FBXHandednessModeTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/FBXHandednessModeTests.cs
@@ -45,7 +45,7 @@ namespace Unity.Formats.USD.Tests
             importOptions.changeHandedness = changeHandedness;
             importOptions.scale = 0.01f;
             importOptions.materialImportMode = MaterialImportMode.ImportDisplayColor;
-            var usdRoot = USD.UsdMenu.ImportSceneAsGameObject(scene, importOptions);
+            var usdRoot = ImportHelpers.ImportSceneAsGameObject(scene, importOptions);
             scene.Close();
             return usdRoot;
         }
@@ -118,7 +118,7 @@ namespace Unity.Formats.USD.Tests
                     break;
                 case BasisTransformation.None:
                 case BasisTransformation.FastWithNegativeScale:
-                    // When comparing the mesh, importing with FastWithNegativeScale and None 
+                    // When comparing the mesh, importing with FastWithNegativeScale and None
                     // will give the same result.
                     bakedLeftHandedMesh = bakedLeftHandedCube_none;
                     break;
@@ -148,7 +148,7 @@ namespace Unity.Formats.USD.Tests
             for(int i = 0; i < cubeMesh.vertices.Length; i++)
             {
                 Assert.IsTrue(CheckVector3Equality(leftHandedCubeMesh.vertices[i], cubeMesh.vertices[i]),
-                    string.Format("Vertex at index {0} of left and right handed cube mesh are not equal, expected equal:\nExpected:{1}\nActual:{2}", 
+                    string.Format("Vertex at index {0} of left and right handed cube mesh are not equal, expected equal:\nExpected:{1}\nActual:{2}",
                                     i, cubeMesh.vertices[i], leftHandedCubeMesh.vertices[i]));
             }
             NUnit.Framework.Assert.That(cubeMesh.triangles, Is.Not.EqualTo(leftHandedCubeMesh.triangles));
@@ -158,19 +158,19 @@ namespace Unity.Formats.USD.Tests
             {
                 // check that normals are flipped
                 Assert.IsTrue(CheckVector3Equality(leftHandedCubeMesh.normals[i], -cubeMesh.normals[i]),
-                    string.Format("Normal at index {0} of left and right handed cube mesh are not equal, expected equal\nExpected:{1}\nActual:{2}", 
+                    string.Format("Normal at index {0} of left and right handed cube mesh are not equal, expected equal\nExpected:{1}\nActual:{2}",
                                     i, -cubeMesh.normals[i], leftHandedCubeMesh.normals[i]));
             }
 
             // Check that the imported left handed cube matches the baked cube.
             var bakedCubeMesh = bakedLeftHandedMesh as Mesh;
             Assert.IsNotNull(bakedCubeMesh);
-            
+
             NUnit.Framework.Assert.That(leftHandedCubeMesh.vertices.Length, Is.EqualTo(bakedCubeMesh.vertices.Length));
             for (int i = 0; i < bakedCubeMesh.vertices.Length; i++)
             {
                 Assert.IsTrue(CheckVector3Equality(leftHandedCubeMesh.vertices[i], bakedCubeMesh.vertices[i]),
-                    string.Format("Vertex at index {0} of left handed and baked cube mesh are not equal, expected equal:\nExpected:{1}\nActual:{2}", 
+                    string.Format("Vertex at index {0} of left handed and baked cube mesh are not equal, expected equal:\nExpected:{1}\nActual:{2}",
                                     i, bakedCubeMesh.vertices[i], leftHandedCubeMesh.vertices[i]));
             }
             NUnit.Framework.Assert.That(bakedCubeMesh.triangles, Is.EqualTo(leftHandedCubeMesh.triangles));

--- a/package/com.unity.formats.usd/Tests/Editor/ImportHelpersTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/ImportHelpersTests.cs
@@ -1,0 +1,102 @@
+﻿using System.IO;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using USD.NET;
+using USD.NET.Unity;
+using Object = UnityEngine.Object;
+
+namespace Unity.Formats.USD.Tests
+{
+    public class ImportHelpersTests : BaseFixtureEditor
+    {
+        Scene CreateTestAsset(string fileName)
+        {
+            var dummyUsdPath = CreateTmpUsdFile(fileName);
+            var scene = ImportHelpers.InitForOpen(dummyUsdPath);
+            scene.Write("/root", new XformSample());
+            scene.Write("/root/sphere", new SphereSample());
+            scene.Save();
+            return scene;
+        }
+
+        [Test]
+        public void ImportAsPrefabTest_ContentOk()
+        {
+            var scene = CreateTestAsset("dummyUsd.usda");
+            var assetPath = ImportHelpers.ImportAsPrefab(scene);
+            Assert.IsNull(scene.Stage, "Scene was not closed after import.");
+
+            m_assetsToDelete.Add(assetPath);
+
+            Assert.IsTrue(File.Exists(assetPath));
+            var allObjects = AssetDatabase.LoadAllAssetsAtPath(assetPath);
+            Assert.NotZero(allObjects.Length);
+            bool playableAssetFound = false;
+            int goCount = 0;
+            int materialCount = 0;
+            foreach (Object thisObject in allObjects)
+            {
+                string myType = thisObject.GetType().Name;
+                if (myType == "UsdPlayableAsset")
+                {
+                    playableAssetFound = true;
+                }
+                else if (myType == "GameObject")
+                {
+                    goCount += 1;
+                }
+                else if (myType == "Material")
+                {
+                    materialCount += 1;
+                }
+            }
+
+            Assert.IsTrue(playableAssetFound, "No PlayableAssset was found in the prefab.");
+            Assert.AreEqual(2, goCount, "Wrong GameObjects count in the prefab.");
+            // The 3 default materials + 1 material per meshRender
+            Assert.AreEqual(4, materialCount, "Wrong Materials count in the prefab");
+        }
+
+        [Test]
+        public void ImportAsTimelineClipTest_ContentOk()
+        {
+            // Import as timeline clip should not create a hierarchy, only the root and the playable
+            var scene = CreateTestAsset("dummyUsd.usda");
+            var assetPath = ImportHelpers.ImportAsTimelineClip(scene);
+            Assert.IsNull(scene.Stage, "Scene was not closed after import.");
+            m_assetsToDelete.Add(assetPath);
+
+            Assert.IsTrue(File.Exists(assetPath));
+            var allObjects = AssetDatabase.LoadAllAssetsAtPath(assetPath);
+            Assert.NotZero(allObjects.Length);
+            bool playableAssetFound = false;
+            int goCount = 0;
+            int materialCount = 0;
+            foreach (Object thisObject in allObjects)
+            {
+                Debug.Log(thisObject.name);
+                Debug.Log(thisObject.GetType().Name);
+                string myType = thisObject.GetType().Name;
+                if (myType == "UsdPlayableAsset")
+                {
+                    playableAssetFound = true;
+                }
+                else if (myType == "GameObject")
+                {
+                    goCount += 1;
+                }
+                else if (myType == "Material")
+                {
+                    materialCount += 1;
+                }
+            }
+
+            Assert.IsTrue(playableAssetFound, "No PlayableAssset was found in the prefab.");
+            Assert.AreEqual(1, goCount, "Wrong GameObjects count in the prefab.");
+            // Only 3 default materials and no meshRenderer
+            Assert.AreEqual(3, materialCount, "Wrong Materials count in the prefab");
+
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Editor/ImportHelpersTests.cs.meta
+++ b/package/com.unity.formats.usd/Tests/Editor/ImportHelpersTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 143351b19be54bd09af574fbf90d8132
+timeCreated: 1614118256

--- a/package/com.unity.formats.usd/Tests/Editor/USDPayloadComponentTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/USDPayloadComponentTests.cs
@@ -11,7 +11,7 @@ namespace Unity.Formats.USD.Tests
     public class USDPayloadComponentTests
     {
         const string k_USDGUID = "5f0268198d3d7484cb1877bec2c5d31f"; // GUID of test_collections.usda
- 
+
         private GameObject m_usdRoot;
         private UsdAsset m_usdAsset;
 
@@ -22,7 +22,7 @@ namespace Unity.Formats.USD.Tests
             var usdPath = Path.GetFullPath(AssetDatabase.GUIDToAssetPath(k_USDGUID));
             var stage = pxr.UsdStage.Open(usdPath, pxr.UsdStage.InitialLoadSet.LoadNone);
             var scene = Scene.Open(stage);
-            m_usdRoot = USD.UsdMenu.ImportSceneAsGameObject(scene);
+            m_usdRoot = ImportHelpers.ImportSceneAsGameObject(scene);
             scene.Close();
 
             m_usdAsset = m_usdRoot.GetComponent<UsdAsset>();

--- a/package/com.unity.formats.usd/Tests/Editor/Unity.Formats.USD.Tests.Editor.asmdef
+++ b/package/com.unity.formats.usd/Tests/Editor/Unity.Formats.USD.Tests.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "Unity.Formats.USD.Tests.Editor",
     "references": [
         "Unity.Formats.USD.Runtime",
-        "Unity.Formats.USD.Editor"
+        "Unity.Formats.USD.Editor",
+        "Unity.Formats.USD.Tests"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"

--- a/package/com.unity.formats.usd/Tests/Editor/UsdAssetReloadTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/UsdAssetReloadTests.cs
@@ -18,7 +18,7 @@ namespace Unity.Formats.USD.Tests
 
         string testFilePath;
         string testFileModifiedPath;
-        
+
         GameObject m_usdRoot;
         UsdAsset m_usdAsset;
 
@@ -29,7 +29,7 @@ namespace Unity.Formats.USD.Tests
             testFilePath = Path.GetFullPath(AssetDatabase.GUIDToAssetPath(k_USDGUID));
             var stage = pxr.UsdStage.Open(testFilePath, pxr.UsdStage.InitialLoadSet.LoadNone);
             var scene = Scene.Open(stage);
-            m_usdRoot = UsdMenu.ImportSceneAsGameObject(scene);
+            m_usdRoot = ImportHelpers.ImportSceneAsGameObject(scene);
             scene.Close();
 
             m_usdAsset = m_usdRoot.GetComponent<UsdAsset>();
@@ -46,7 +46,7 @@ namespace Unity.Formats.USD.Tests
             // Restore test files.
             ResetTestFile();
         }
-        
+
         [UnityTest]
         public IEnumerator UsdAsset_Reload_FileHasChanged_NewValuesAreRetrieved()
         {
@@ -55,21 +55,21 @@ namespace Unity.Formats.USD.Tests
             m_usdAsset.GetScene().Read("/TestPrim", xform);
             var translate = xform.transform.GetColumn(3);
             Assert.AreEqual(new Vector4(1, 1, 1, 1), translate);
-            
+
             yield return new WaitForSecondsRealtime(1f);
             // Simulate the fact that the usd file was changed on disk.
             UpdateTestFile();
 
             // Refresh the asset.
             m_usdAsset.Reload(false);
-            
+
             // Ensure the new attribute's values can be retrieved.
             m_usdAsset.GetScene().Read("/TestPrim", xform);
             translate = xform.transform.GetColumn(3);
             Assert.AreEqual(new Vector4(2, 2, 2, 1), translate);
             yield return new WaitForSecondsRealtime(1f);
         }
-        
+
         [UnityTest]
         public IEnumerator UsdAsset_Reload_FileHasChangedAndForceRebuild_NewValuesAreRetrieved()
         {
@@ -82,17 +82,17 @@ namespace Unity.Formats.USD.Tests
             yield return new WaitForSecondsRealtime(1f);
             // Simulate the fact that the usd file was changed on disk.
             UpdateTestFile();
-            
+
             // Reload the asset.
             m_usdAsset.Reload(true);
-            
+
             // Ensure the new attribute's values can be retrieved.
             m_usdAsset.GetScene().Read("/TestPrim", xform);
             translate = xform.transform.GetColumn(3);
             Assert.AreEqual(new Vector4(2, 2, 2, 1), translate);
             yield return new WaitForSecondsRealtime(1f);
         }
-        
+
         [Test]
         public void UsdAsset_Reload_FileDidNotChange_ValuesDoNotChange()
         {
@@ -104,7 +104,7 @@ namespace Unity.Formats.USD.Tests
 
             // Refresh the asset.
             m_usdAsset.Reload(false);
-            
+
             // Ensure that nothing changed.
             m_usdAsset.GetScene().Read("/TestPrim", xform);
             translate = xform.transform.GetColumn(3);
@@ -114,7 +114,7 @@ namespace Unity.Formats.USD.Tests
         void UpdateTestFile()
         {
             testFileModifiedPath = Path.GetFullPath(AssetDatabase.GUIDToAssetPath(k_USDModifiedGUID));
-            
+
             File.WriteAllBytes(testFilePath, File.ReadAllBytes(testFileModifiedPath));
         }
 

--- a/package/com.unity.formats.usd/Tests/Runtime/BaseFixture.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/BaseFixture.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using Scene = USD.NET.Scene;
+
+namespace Unity.Formats.USD.Tests
+{
+    public class BaseFixture
+    {
+        public readonly List<string> m_filesToDelete = new List<string>();
+
+        [SetUp]
+        public void Setup()
+        {
+            InitUsd.Initialize();
+        }
+
+        public string CreateTmpUsdFile(string fileName)
+        {
+            var filePath = System.IO.Path.Combine(UnityEngine.Application.dataPath, fileName);
+            var scene = Scene.Create(filePath);
+            scene.Save();
+            scene.Close();
+            m_filesToDelete.Add(filePath);
+            return filePath;
+        }
+
+        [TearDown]
+        public void DeleteTmpFiles()
+        {
+            foreach (var file in m_filesToDelete)
+            {
+                File.Delete(file);
+            }
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Runtime/BaseFixture.cs.meta
+++ b/package/com.unity.formats.usd/Tests/Runtime/BaseFixture.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 48c5f62571914f7b9581bb424e75429c
+timeCreated: 1614183414

--- a/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs
@@ -1,0 +1,100 @@
+﻿using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+using USD.NET;
+
+namespace Unity.Formats.USD.Tests
+{
+    public class ExportHelpersTests : BaseFixture
+    {
+        [Test]
+        public void InitForSave_EmptyFile()
+        {
+            var scene = ExportHelpers.InitForSave("");
+            Assert.IsNull(scene);
+        }
+
+        [Test]
+        public void InitForSave_NullFile()
+        {
+            var scene = ExportHelpers.InitForSave(null);
+            Assert.IsNull(scene);
+        }
+
+        [Test]
+        public void InitForSave_ValidPath()
+        {
+            var filePath = System.IO.Path.Combine(Application.dataPath, "dummyUsd.usd");
+            m_filesToDelete.Add(filePath);
+            var scene = ExportHelpers.InitForSave(filePath);
+            Assert.IsNotNull(scene);
+            Assert.IsNotNull(scene.Stage);
+            scene.Close();
+        }
+
+        [Test]
+        public void ExportGameObjects_NullScene()
+        {
+            var filePath = CreateTmpUsdFile("dummyUsd.usda");
+            var scene = Scene.Open(filePath);
+            scene.Close();
+            var fileInfoBefore = new FileInfo(filePath);
+
+            Assert.DoesNotThrow(delegate()
+            {
+                ExportHelpers.ExportGameObjects(null, null, BasisTransformation.SlowAndSafe);
+            });
+            var fileInfoAfter = new FileInfo(filePath);
+            Assert.AreEqual(fileInfoBefore.Length, fileInfoAfter.Length);
+        }
+
+        [Test]
+        public void ExportGameObjects_EmptyList()
+        {
+            var filePath = CreateTmpUsdFile("dummyUsd.usda");
+            var scene = Scene.Open(filePath);
+            var fileInfoBefore = new FileInfo(filePath);
+            Assert.DoesNotThrow(delegate()
+            {
+                ExportHelpers.ExportGameObjects(new GameObject [] {}, scene, BasisTransformation.SlowAndSafe);
+            });
+            var fileInfoAfter = new FileInfo(filePath);
+            Assert.AreEqual(fileInfoBefore.Length, fileInfoAfter.Length);
+        }
+
+        [Test]
+        public void ExportGameObjects_InvalidGO()
+        {
+
+            var filePath = CreateTmpUsdFile("dummyUsd.usda");
+            var scene = Scene.Open(filePath);
+            Assert.DoesNotThrow(delegate()
+            {
+                ExportHelpers.ExportGameObjects(new GameObject[] {null}, scene, BasisTransformation.SlowAndSafe);
+            });
+            UnityEngine.TestTools.LogAssert.Expect(LogType.Exception, "NullReferenceException: Object reference not set to an instance of an object");
+        }
+
+        [Test]
+        public void ExportGameObjects_ValidGO()
+        {
+            var filePath = CreateTmpUsdFile("dummyUsd.usda");
+            var scene = Scene.Open(filePath);
+            ExportHelpers.ExportGameObjects(new [] {new GameObject("test")}, scene, BasisTransformation.SlowAndSafe);
+            scene = Scene.Open(filePath);
+            var paths = scene.Stage.GetAllPaths();
+            Debug.Log(scene.Stage.GetRootLayer().ExportToString());
+            Assert.AreEqual(2, paths.Count);
+        }
+
+        [Test]
+        public void ExportGameObjects_SceneClosedAfterExport()
+        {
+
+            var filePath = CreateTmpUsdFile("dummyUsd.usda");
+            var scene = Scene.Open(filePath);
+            ExportHelpers.ExportGameObjects(new [] {new GameObject("test")}, scene, BasisTransformation.SlowAndSafe);
+            Assert.IsNull(scene.Stage);
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs
@@ -60,6 +60,7 @@ namespace Unity.Formats.USD.Tests
             });
             var fileInfoAfter = new FileInfo(filePath);
             Assert.AreEqual(fileInfoBefore.Length, fileInfoAfter.Length);
+            scene.Close();
         }
 
         [Test]
@@ -85,6 +86,7 @@ namespace Unity.Formats.USD.Tests
             var paths = scene.Stage.GetAllPaths();
             Debug.Log(scene.Stage.GetRootLayer().ExportToString());
             Assert.AreEqual(2, paths.Count);
+            scene.Close();
         }
 
         [Test]

--- a/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs.meta
+++ b/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c2d9cd48bd0ff74da194631282f5733
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/Runtime/ImportHelpersTests.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/ImportHelpersTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using USD.NET.Unity;
+using Scene = USD.NET.Scene;
+
+namespace Unity.Formats.USD.Tests
+{
+    public class ImportHelpersTests : BaseFixture
+    {
+        Scene CreateTmpUsdWithData(string fileName)
+        {
+            var dummyUsdPath = CreateTmpUsdFile(fileName);
+            var scene = ImportHelpers.InitForOpen(dummyUsdPath);
+            scene.Write("/root", new XformSample());
+            scene.Write("/root/sphere", new SphereSample());
+            scene.Save();
+            return scene;
+        }
+
+        [Test]
+        public void InitForOpenTest_ValidPath_Succeeds()
+        {
+            var dummyUsdPath = CreateTmpUsdFile("dummyUsd.usda");
+            var scene = ImportHelpers.InitForOpen(dummyUsdPath);
+            Assert.NotNull(scene);
+            Assert.NotNull(scene.Stage);
+            scene.Close();
+        }
+
+        [Test]
+        public void InitForOpenTest_EmptyPath()
+        {
+            var scene = ImportHelpers.InitForOpen("");
+            Assert.IsNull(scene);
+        }
+
+        [Test]
+        public void InitForOpenTest_InvalidPath_ThrowsAndLogs()
+        {
+            var ex = Assert.Throws<NullReferenceException>(
+                delegate { ImportHelpers.InitForOpen("/this/is/an/invalid/path.usd"); }, "Opening a non existing file should throw an NullReferenceException");
+            Assert.That(ex.Message, Is.EqualTo("Null stage"));
+            UnityEngine.TestTools.LogAssert.Expect(LogType.Exception, "ApplicationException: USD ERROR: Failed to open layer @/this/is/an/invalid/path.usd@");
+        }
+
+        [Test]
+        public void ImportAsGameObjects_ImportAtRoot()
+        {
+            var scene = CreateTmpUsdWithData("dummyUsd.usda");
+            var root = ImportHelpers.ImportSceneAsGameObject(scene);
+            bool usdRootIsRoot = Array.Find(SceneManager.GetActiveScene().GetRootGameObjects(), r => r == root);
+            Assert.IsTrue(usdRootIsRoot, "UsdAsset GameObject is not a root GameObject.");
+        }
+
+        [Test]
+        public void ImportAsGameObjects_ImportUnderParent()
+        {
+            var root = new GameObject("thisIsTheRoot");
+            var scene = CreateTmpUsdWithData("dummyUsd.usda");
+            var usdRoot = ImportHelpers.ImportSceneAsGameObject(scene, root);
+            Assert.AreEqual(root.transform, usdRoot.transform.root, "UsdAsset is not a children of the given parent.");
+        }
+
+        [Test]
+        public void ImportAsGameObjects_SceneClosedAfterImport()
+        {
+            var scene = CreateTmpUsdWithData("dummyUsd.usda");
+            var root = ImportHelpers.ImportSceneAsGameObject(scene);
+            Assert.IsNull(scene.Stage, "Scene was not closed after import.");
+        }
+
+        [Test]
+        public void ImportAsGameObjects_ImportClosedScene_LogsError()
+        {
+            var rootGOsBefore = SceneManager.GetActiveScene().GetRootGameObjects();
+            var scene = CreateTmpUsdWithData("dummyUsd.usda");
+            scene.Close();
+            var root = ImportHelpers.ImportSceneAsGameObject(scene);
+            Assert.IsNull(root);
+            UnityEngine.TestTools.LogAssert.Expect(LogType.Error, "The USD Scene needs to be opened before being imported.");
+        }
+
+        [Test]
+        [Ignore("TODO")]
+        public void ImportAsGameObjects_CleanupAfterError()
+        {
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Runtime/ImportHelpersTests.cs.meta
+++ b/package/com.unity.formats.usd/Tests/Runtime/ImportHelpersTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76b0426308aaf2749bf68b2b913a1a52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/Runtime/RuntimeTests.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/RuntimeTests.cs
@@ -11,10 +11,8 @@ using Scene = USD.NET.Scene;
 
 namespace Unity.Formats.USD.Tests
 {
-    public class SanityTest
+    public class SanityTest : BaseFixture
     {
-        List<string> filesToDelete = new List<string>();
-
         class MyCustomData : SampleBase
         {
             public string aString;
@@ -31,8 +29,6 @@ namespace Unity.Formats.USD.Tests
         [Test]
         public void CanWriteCustomData()
         {
-            string usdFile = System.IO.Path.Combine(UnityEngine.Application.dataPath, "sceneFile.usda");
-            filesToDelete.Add(usdFile);
             // Populate Values.
             var value = new MyCustomData();
             value.aString = "IT'S ALIIIIIIIIIIIIIVE!";
@@ -40,14 +36,15 @@ namespace Unity.Formats.USD.Tests
             value.aBoundingBox = new UnityEngine.Bounds();
 
             // Writing the value.
-            var scene = Scene.Create(usdFile);
+            string usdFile = CreateTmpUsdFile("sceneFile.usda");
+            var scene = ImportHelpers.InitForOpen(usdFile);
             scene.Time = 1.0;
             scene.Write("/someValue", value);
             Debug.Log(scene.Stage.GetRootLayer().ExportToString());
             scene.Save();
             scene.Close();
 
-            Assert.IsTrue(File.Exists(usdFile));
+            Assert.IsTrue(File.Exists(usdFile), "File not found.");
 
             // Reading the value.
             Debug.Log(usdFile);
@@ -56,25 +53,9 @@ namespace Unity.Formats.USD.Tests
             scene.Time = 1.0;
             scene.Read("/someValue", newValue);
 
-            Assert.AreEqual(value.aString, newValue.aString);
+            Assert.AreEqual(value.aString, newValue.aString, "Serialized data don't match the original data.");
 
             scene.Close();
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            foreach (var file in filesToDelete)
-            {
-                try
-                {
-                    File.Delete(file);
-                }
-                catch (Exception)
-                {
-                    // ignored
-                }
-            }
         }
     }
 }

--- a/package/com.unity.formats.usd/Tests/Runtime/Unity.Formats.USD.Tests.asmdef
+++ b/package/com.unity.formats.usd/Tests/Runtime/Unity.Formats.USD.Tests.asmdef
@@ -2,10 +2,9 @@
     "name": "Unity.Formats.USD.Tests",
     "references": [
         "Unity.Formats.USD.Runtime",
-        "Unity.Timeline"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "Unity.Timeline",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
     ],
     "includePlatforms": [
         "Editor",
@@ -17,8 +16,14 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "USD.NET.dll"
+        "USD.NET.dll",
+        "USD.NET.Unity.dll",
+        "nunit.framework.dll"
     ],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** https://jira.unity3d.com/browse/USDU-155

Preparatory work for the mesh import/conversion layer fixes.
UsdMenu used to contain a lot of import logic making it hard to reuse and test. All the logic has been moved to 2 new static classes ImportHelpers and ExportHelpers.

## Testing

**Functional Testing status:**
Tried to cover 100% of the Import/ExportHelpers. 

**Performance Testing status:**
N/A

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
Low

**Halo Effect:**
Low

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
