### PR TITLE
USDU-48: Fix hardcoded package path in PostBuildProcess and add tests

### DIFF
--- a/package/com.unity.formats.usd/Editor/Scripts/UsdBuildPostProcess.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/UsdBuildPostProcess.cs
@@ -1,18 +1,4 @@
-﻿// Copyright 2018 Pixar Animation Studios
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-using UnityEngine;
+﻿using System.Runtime.CompilerServices;
 using UnityEditor;
 using UnityEditor.Callbacks;
 
@@ -23,7 +9,7 @@ namespace Unity.Formats.USD
         [PostProcessBuildAttribute(1)]
         public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject)
         {
-            var source = System.IO.Path.GetFullPath("Packages/com.unity.formats.usd/Runtime/Plugins");
+            var source = System.IO.Path.Combine(GetCurrentDir(), "..", "..", "Runtime", "Plugins");
             var destination = "";
             if (target == BuildTarget.StandaloneLinux64)
             {
@@ -41,6 +27,12 @@ namespace Unity.Formats.USD
             // We need to copy the whole share folder and this one plugInfo.json file
             FileUtil.CopyFileOrDirectory(source + "/x86_64/usd", destination + "/usd");
             FileUtil.CopyFileOrDirectory(source + "/x86_64/plugInfo.json", destination + "/plugInfo.json");
+        }
+
+        static string GetCurrentDir([CallerFilePath] string filePath = "")
+        {
+            var fileInfo = new System.IO.FileInfo(filePath);
+            return fileInfo.DirectoryName;
         }
     }
 }

--- a/package/com.unity.formats.usd/Editor/Scripts/UsdBuildPostProcess.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/UsdBuildPostProcess.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.IO;
+using System.Runtime.CompilerServices;
 using UnityEditor;
 using UnityEditor.Callbacks;
 
@@ -9,7 +10,7 @@ namespace Unity.Formats.USD
         [PostProcessBuildAttribute(1)]
         public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject)
         {
-            var source = System.IO.Path.Combine(GetCurrentDir(), "..", "..", "Runtime", "Plugins");
+            var source = Path.Combine(GetCurrentDir(), "..", "..", "Runtime", "Plugins");
             var destination = "";
             if (target == BuildTarget.StandaloneLinux64)
             {
@@ -31,7 +32,7 @@ namespace Unity.Formats.USD
 
         static string GetCurrentDir([CallerFilePath] string filePath = "")
         {
-            var fileInfo = new System.IO.FileInfo(filePath);
+            var fileInfo = new FileInfo(filePath);
             return fileInfo.DirectoryName;
         }
     }

--- a/package/com.unity.formats.usd/Tests/Editor/PostBuildTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/PostBuildTests.cs
@@ -1,0 +1,49 @@
+﻿using NUnit.Framework;
+using System.IO;
+using UnityEditor;
+using Assert = UnityEngine.Assertions.Assert;
+
+namespace Unity.Formats.USD.Tests
+{
+    public class PostBuildTests
+    {
+        BuildPlayerOptions m_buildOptions;
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_buildOptions = new BuildPlayerOptions();
+            m_buildOptions.locationPathName = "../testBuild/dummy.exe";
+            m_buildOptions.options = BuildOptions.None;
+
+#if UNITY_EDITOR_WIN
+            m_buildOptions.target = BuildTarget.StandaloneWindows64;
+#elif UNITY_EDITOR_OSX
+            m_buildOptions.target = BuildTarget.StandaloneOSX;
+#elif UNITY_EDITOR_LINUX
+            m_buildOptions.target = BuildTarget.StandaloneLinux64;
+#endif
+
+            m_buildOptions.options = BuildOptions.None;
+
+            BuildPipeline.BuildPlayer(m_buildOptions);
+        }
+
+        [TearDown]
+        public void DeleteBuildFolder()
+        {
+            var buildFolder = new FileInfo(m_buildOptions.locationPathName).Directory;
+            Directory.Delete(buildFolder.FullName, true);
+        }
+
+
+        [Test]
+        public void PostBuild_UsdPluginsCopy()
+        {
+            var buildFolder = new FileInfo(m_buildOptions.locationPathName).Directory;
+            var dirs = buildFolder.GetDirectories("usd", SearchOption.AllDirectories);
+
+            Assert.IsNotNull(dirs, "The usd plugins directories were not found in the build.");
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Editor/PostBuildTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/PostBuildTests.cs
@@ -45,6 +45,7 @@ namespace Unity.Formats.USD.Tests
             var buildFolder = new FileInfo(m_buildOptions.locationPathName).Directory;
             var dirs = buildFolder.GetDirectories("usd", SearchOption.AllDirectories);
 
+            Assert.IsTrue(File.Exists(m_buildOptions.locationPathName), "Executable not found. Build failed");
             Assert.IsNotNull(dirs, "The usd plugins directories were not found in the build.");
         }
     }

--- a/package/com.unity.formats.usd/Tests/Editor/PostBuildTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/PostBuildTests.cs
@@ -15,14 +15,15 @@ namespace Unity.Formats.USD.Tests
             m_buildOptions = new BuildPlayerOptions();
             m_buildOptions.options = BuildOptions.None;
 
+            var tmpPath = System.IO.Path.GetTempPath();
 #if UNITY_EDITOR_WIN
-            m_buildOptions.locationPathName = "../testBuild/dummy.exe";
+            m_buildOptions.locationPathName = Path.Combine(tmpPath, "testBuild", "dummy.exe");
             m_buildOptions.target = BuildTarget.StandaloneWindows64;
 #elif UNITY_EDITOR_OSX
-            m_buildOptions.locationPathName = "../testBuild/dummy";
+            m_buildOptions.locationPathName = Path.Combine(tmpPath, "testBuild", "dummy");
             m_buildOptions.target = BuildTarget.StandaloneOSX;
 #elif UNITY_EDITOR_LINUX
-            m_buildOptions.locationPathName = "../testBuild/dummy.x86_64";
+            m_buildOptions.locationPathName = Path.Combine(tmpPath, "testBuild", "dummy.x86_64");
             m_buildOptions.target = BuildTarget.StandaloneLinux64;
 #endif
 

--- a/package/com.unity.formats.usd/Tests/Editor/PostBuildTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/PostBuildTests.cs
@@ -13,14 +13,16 @@ namespace Unity.Formats.USD.Tests
         public void SetUp()
         {
             m_buildOptions = new BuildPlayerOptions();
-            m_buildOptions.locationPathName = "../testBuild/dummy.exe";
             m_buildOptions.options = BuildOptions.None;
 
 #if UNITY_EDITOR_WIN
+            m_buildOptions.locationPathName = "../testBuild/dummy.exe";
             m_buildOptions.target = BuildTarget.StandaloneWindows64;
 #elif UNITY_EDITOR_OSX
+            m_buildOptions.locationPathName = "../testBuild/dummy";
             m_buildOptions.target = BuildTarget.StandaloneOSX;
 #elif UNITY_EDITOR_LINUX
+            m_buildOptions.locationPathName = "../testBuild/dummy.x86_64";
             m_buildOptions.target = BuildTarget.StandaloneLinux64;
 #endif
 

--- a/package/com.unity.formats.usd/Tests/Editor/PostBuildTests.cs.meta
+++ b/package/com.unity.formats.usd/Tests/Editor/PostBuildTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e98cb32a8800443ba9ff06fe18312f1e
+timeCreated: 1615243036


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** https://jira.unity3d.com/browse/USDU-48

Forgot one more hard-coded package path in #236 
This also adds a test for the BuildPostProcess step. 


## Testing

**Functional Testing status:**

Tested manually by renaming the package locally.

**Performance Testing status:**
N/A

## Overall Product Risks
Minimal

**Complexity:**
Minimal

**Halo Effect:**
Minimal

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
