### PR TITLE
Remove .NET4 requirement

### DIFF
--- a/package/com.unity.formats.usd/Dependencies/USD.NET/serialization/CodeGen.cs
+++ b/package/com.unity.formats.usd/Dependencies/USD.NET/serialization/CodeGen.cs
@@ -17,6 +17,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 
 
+#if NET_4_6
 static internal class CodeGen
 {
     private static int m_funcCount = 0;
@@ -104,3 +105,4 @@ static internal class CodeGen
         return fn.CreateDelegate(typeof(T));
     }
 }
+#endif


### PR DESCRIPTION
## Purpose of this PR

Moving USD.NET in the package enforced .NET 4 requirement and cause compilation errors in .NET 2 situation.
This removes the .NET 4 requirement by using the slower late binding used for IL2CPP builds.