### PR TITLE
JIRA: USDU-168 Writing to an invalid prim crashes Unity

### DIFF
--- a/package/com.unity.formats.usd/Tests/USD.NET/StageTests.cs
+++ b/package/com.unity.formats.usd/Tests/USD.NET/StageTests.cs
@@ -310,5 +310,17 @@ namespace USD.NET.Tests
             Assert.IsTrue(prim.IsValid() == false);
             stage.Dispose();
         }
+
+        [Test]
+        public void WritingInvalidPrims_ShouldNotCrash()
+        {
+            var stage = pxr.UsdStage.CreateInMemory(UsdStage.InitialLoadSet.LoadNone);
+            var scene = Scene.Open(stage);
+            scene.Write("/Foo", new CubeSample());
+            scene.Stage.RemovePrim(scene.GetSdfPath("/Foo"));
+            scene.Write("/Foo", new CubeSample());
+
+            Assert.IsTrue(scene.GetPrimAtPath("/Foo").IsValid());
+        }
     }
 }


### PR DESCRIPTION
## Purpose of this PR

USDU-168 Writing to an invalid prim crashes Unity

Bug was related to the PrimMap being out of date. 

## Testing

Unit test added

