### PR TITLE
Add missing alembic plugin (USDU-129)

### DIFF
--- a/TestProject/Usd-Development/Packages/manifest.json
+++ b/TestProject/Usd-Development/Packages/manifest.json
@@ -1,10 +1,12 @@
 {
   "dependencies": {
+    "com.unity.analytics": "3.5.3",
     "com.unity.coding": "0.1.0-preview.20",
-    "com.unity.analytics": "3.3.5",
-    "com.unity.ext.nunit": "1.0.0",
+    "com.unity.ext.nunit": "1.0.6",
     "com.unity.formats.usd": "file:../../../package/com.unity.formats.usd/",
-    "com.unity.test-framework": "1.1.11",
+    "com.unity.ide.rider": "1.1.4",
+    "com.unity.recorder": "2.5.5",
+    "com.unity.test-framework": "1.1.24",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",

--- a/TestProject/Usd-Development/Packages/packages-lock.json
+++ b/TestProject/Usd-Development/Packages/packages-lock.json
@@ -1,28 +1,7 @@
 {
   "dependencies": {
-    "com.unity.2d.sprite": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.2d.tilemap": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.ads": {
-      "version": "3.7.1",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.analytics": {
-      "version": "3.3.5",
+      "version": "3.5.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -37,13 +16,6 @@
       "dependencies": {
         "nuget.moq": "1.0.0"
       },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.collab-proxy": {
-      "version": "1.2.16",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.ext.nunit": {
@@ -64,7 +36,7 @@
       }
     },
     "com.unity.ide.rider": {
-      "version": "1.2.1",
+      "version": "1.1.4",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -72,32 +44,12 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.ide.vscode": {
-      "version": "1.2.3",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.multiplayer-hlapi": {
-      "version": "1.0.8",
+    "com.unity.recorder": {
+      "version": "2.5.5",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "nuget.mono-cecil": "0.1.6-preview"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.purchasing": {
-      "version": "3.0.2",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0",
-        "com.unity.modules.unityanalytics": "1.0.0",
-        "com.unity.modules.unitywebrequest": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0",
-        "com.unity.modules.androidjni": "1.0.0"
+        "com.unity.timeline": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -112,18 +64,9 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.textmeshpro": {
-      "version": "2.1.4",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.timeline": {
-      "version": "1.2.18",
-      "depth": 0,
+      "version": "1.5.4",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.modules.director": "1.0.0",
@@ -135,33 +78,16 @@
     },
     "com.unity.ugui": {
       "version": "1.0.0",
-      "depth": 0,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {
         "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0"
       }
     },
-    "com.unity.xr.legacyinputhelpers": {
-      "version": "2.1.7",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.modules.vr": "1.0.0",
-        "com.unity.modules.xr": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
     "nuget.castle-core": {
       "version": "1.0.1",
       "depth": 2,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "nuget.mono-cecil": {
-      "version": "0.1.6-preview",
-      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -176,12 +102,6 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.modules.ai": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
-    },
-    "com.unity.modules.androidjni": {
       "version": "1.0.0",
       "depth": 0,
       "source": "builtin",
@@ -308,6 +228,18 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.uielementsnative": "1.0.0"
+      }
+    },
+    "com.unity.modules.uielementsnative": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       }

--- a/package/com.unity.formats.usd/Runtime/Plugins/x86_64/usd/usdAbc.meta
+++ b/package/com.unity.formats.usd/Runtime/Plugins/x86_64/usd/usdAbc.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 898e07b886df4f2419397ff1e5879b8a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Runtime/Plugins/x86_64/usd/usdAbc/resources.meta
+++ b/package/com.unity.formats.usd/Runtime/Plugins/x86_64/usd/usdAbc/resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 378a93517e3cf9440904fb67a4a26a55
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Runtime/Plugins/x86_64/usd/usdAbc/resources/plugInfo.json
+++ b/package/com.unity.formats.usd/Runtime/Plugins/x86_64/usd/usdAbc/resources/plugInfo.json
@@ -1,0 +1,27 @@
+{
+    "Plugins": [
+        {
+            "Info": {
+                "Types": {
+                    "UsdAbcAlembicFileFormat": {
+                        "bases": [
+                            "SdfFileFormat"
+                        ],
+                        "displayName": "USD Alembic File Format",
+                        "extensions": [
+                            "abc"
+                        ],
+                        "formatId": "abc",
+                        "primary": true,
+                        "target": "usd"
+                    }
+                }
+            },
+            "LibraryPath": "",
+            "Name": "usdAbc",
+            "ResourcePath": "resources",
+            "Root": "..",
+            "Type": "library"
+        }
+    ]
+}

--- a/package/com.unity.formats.usd/Runtime/Plugins/x86_64/usd/usdAbc/resources/plugInfo.json.meta
+++ b/package/com.unity.formats.usd/Runtime/Plugins/x86_64/usd/usdAbc/resources/plugInfo.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e74618e735cecba42b184caf9111204c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/USD.NET/Data.meta
+++ b/package/com.unity.formats.usd/Tests/USD.NET/Data.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a1bb24527cd2444fb90859ea0bca52b1
+timeCreated: 1623872669

--- a/package/com.unity.formats.usd/Tests/USD.NET/Data/sphere.abc.meta
+++ b/package/com.unity.formats.usd/Tests/USD.NET/Data/sphere.abc.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8a5705fd5aa52bf4aaa78f290894fd8f
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/USD.NET/PluginsTests.cs
+++ b/package/com.unity.formats.usd/Tests/USD.NET/PluginsTests.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+using UnityEditor;
+
+namespace USD.NET.Tests
+{
+    class PluginTests : UsdTests
+    {
+        const string alembicAssetName = "sphere.abc";
+
+        [Test]
+        public void AlembicTest_Loads()
+        {
+            var alembicPath = System.IO.Path.Combine(GetTestDataDirectoryPath(), alembicAssetName);
+            USD.NET.Scene scene = USD.NET.Scene.Open(alembicPath);
+            var prim = scene.GetPrimAtPath("/Sphere");
+            Assert.IsTrue(prim.IsValid());
+            scene.Close();
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/USD.NET/PluginsTests.cs.meta
+++ b/package/com.unity.formats.usd/Tests/USD.NET/PluginsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a38c4377d5a08d24c9b55af153bb46f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/package/com.unity.formats.usd/Tests/USD.NET/UsdNetTests.cs
+++ b/package/com.unity.formats.usd/Tests/USD.NET/UsdNetTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
+using System.Runtime.CompilerServices;
 
 namespace USD.NET.Tests
 {
@@ -156,6 +157,12 @@ namespace USD.NET.Tests
             {
                 throw new Exception("Values do not match for " + typeof(T).Name);
             }
+        }
+
+        internal static string GetTestDataDirectoryPath([CallerFilePath] string sourceFilePath = "")
+        {
+            var fileInfo = new System.IO.FileInfo(sourceFilePath);
+            return System.IO.Path.Combine(fileInfo.DirectoryName, "Data");
         }
     }
 }

--- a/package/com.unity.formats.usd/Tests/USD.NET/Util/UsdInitializer.cs
+++ b/package/com.unity.formats.usd/Tests/USD.NET/Util/UsdInitializer.cs
@@ -67,7 +67,7 @@ namespace USD.NET.Tests
         {
 #if UNITY_EDITOR
             var fileInfo = new System.IO.FileInfo(sourceFilePath);
-            var supPath = System.IO.Path.Combine(fileInfo.DirectoryName, "Plugins");
+            var supPath = System.IO.Path.Combine(fileInfo.DirectoryName, "..", "..", "..", "Runtime", "Plugins");
 #else
             var supPath = UnityEngine.Application.dataPath.Replace("\\", "/") + "/Plugins";
 #endif

--- a/src/UsdCs/CMakeLists.txt
+++ b/src/UsdCs/CMakeLists.txt
@@ -130,9 +130,11 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 endif()
 install(FILES ${PIXAR_DEPS} DESTINATION ${DEPENDENCIES_INSTALL_DIR})
 
-# Install the usd plugin folder
+# Install the usd schema folder
 install(DIRECTORY "${USD_LIBRARY_DIR}/usd" DESTINATION "${SWIG_OUTPUT_DIR}/.."
         PATTERN "codegenTemplates" EXCLUDE)
+# Install the usd plugin folder
+install(DIRECTORY "${USD_LIBRARY_DIR}/../plugin/usd" DESTINATION "${SWIG_OUTPUT_DIR}/..")
 
 # Tag the generated folders so they are removed when doing calling the clean target
 # Doesn't work with the VC generator ...


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** https://jira.unity3d.com/browse/USDU-129

The USD Alembic plugin files were missing since 2.0.0-exp.1. 
This PR adds the missing files, updates the CMake script to install them when building the bindings, and adds a test.

I also update the packages in the Usd-Development test project (for min version 2019.4)

## Testing

* Load Alembic from the USD menu
*  Works

**Performance Testing status:**

N/A

## Overall Product Risks
N/A

**Complexity:**
Minimal

**Halo Effect:**
Minimal

## Additional information

**Note to reviewers:**

N/A

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [x] Add entry in CHANGELOG.md _(if applicable)_
