### PR TITLE
Prepare release 3.0.0-exp.2

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,12 +1,12 @@
 test_editors:
   - version: trunk
-  - version: 2021.1
+  - version: 2021.2
   - version: 2020.3
   - version: 2019.4
 test_platforms:
   - name: win
     type: Unity::VM
-    image: package-ci/win10:v1.15.0
+    image: package-ci/win10:stable
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx

--- a/package/com.unity.formats.usd/CHANGELOG.md
+++ b/package/com.unity.formats.usd/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Bug Fixes
 - Fixed the import of facevarying UVs which showed seams on Meshes.
 - Fixed an import bug causing abstract primitives to be loaded as Game Objects.
-- Fixed the Alembic support.
+- Fixed the broken Alembic Import.
 - Fixed a crash caused by writing to an invalid USD primitive.
 
 ## [3.0.0-exp.1] - 2021-06-15

--- a/package/com.unity.formats.usd/CHANGELOG.md
+++ b/package/com.unity.formats.usd/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changes in usd-unitysdk for Unity
 
+## [3.0.0-exp.2] - 2021-09-29
+### Features
+- All interpolation types are now properly supported for Mesh standard attributes (normals, tangents, uvs, colors)
+
+### Bug Fixes
+- Fixed the import of facevarying UVs which showing seams on Meshes
+- Fixed a import bug causing abstract primitives to be loaded as Game Objects
+- Fixed the Alembic support
+- Fixed a crash caused by writing to an invalid USD primitive
+
 ## [3.0.0-exp.1] - 2021-06-15
 ### Features
 - New Import/Export API. See the ImportHelpers and ExportHelpers class (#237).

--- a/package/com.unity.formats.usd/CHANGELOG.md
+++ b/package/com.unity.formats.usd/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## [3.0.0-exp.2] - 2021-09-29
 ### Features
-- All interpolation types are now properly supported for Mesh standard attributes (normals, tangents, uvs, colors)
+- All interpolation types are now properly supported for Mesh standard attributes (normals, tangents, uvs, colors).
 
 ### Bug Fixes
-- Fixed the import of facevarying UVs which showing seams on Meshes
-- Fixed a import bug causing abstract primitives to be loaded as Game Objects
-- Fixed the Alembic support
-- Fixed a crash caused by writing to an invalid USD primitive
+- Fixed the import of facevarying UVs which showed seams on Meshes.
+- Fixed an import bug causing abstract primitives to be loaded as Game Objects.
+- Fixed the Alembic support.
+- Fixed a crash caused by writing to an invalid USD primitive.
 
 ## [3.0.0-exp.1] - 2021-06-15
 ### Features

--- a/package/com.unity.formats.usd/package.json
+++ b/package/com.unity.formats.usd/package.json
@@ -30,5 +30,5 @@
         "url": "ssh://git@github.com:Unity-Technologies/usd-unity-sdk.git"
     },
     "unity": "2019.4",
-    "version": "3.0.0-exp.1"
+    "version": "3.0.0-exp.2"
 }


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** https://jira.unity3d.com/browse/USDU-197

Update changelog, bumped package version and changed yamato config to use 2021.2 instead of 2021.1