### PR TITLE
Reduce GC alloc of Scene.GetAttributeAtPath and Scene.GetRelationshipAtPath (USDU-203)

### DIFF
--- a/package/com.unity.formats.usd/CHANGELOG.md
+++ b/package/com.unity.formats.usd/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes in usd-unitysdk for Unity
 
+## Unreleased
+### Changed
+- GC allocs reduced by half for Scene.GetAttributeAtPath and Scene.GetRelationshipAtPath
+
 ## [3.0.0-exp.2] - 2021-09-29
 ### Features
 - All interpolation types are now properly supported for Mesh standard attributes (normals, tangents, uvs, colors).

--- a/package/com.unity.formats.usd/Dependencies/USD.NET/serialization/Scene.cs
+++ b/package/com.unity.formats.usd/Dependencies/USD.NET/serialization/Scene.cs
@@ -335,12 +335,7 @@ namespace USD.NET
         public UsdAttribute GetAttributeAtPath(string attrPath)
         {
             var attrSdfPath = new SdfPath(attrPath);
-            var p = Stage.GetPrimAtPath(attrSdfPath.GetPrimPath());
-            if (p == null || !p.IsValid())
-            {
-                return null;
-            }
-            var a = p.GetAttribute(attrSdfPath.GetNameToken());
+            var a = Stage.GetAttributeAtPath(attrSdfPath);
             if (a == null || !a.IsValid())
             {
                 return null;
@@ -355,12 +350,7 @@ namespace USD.NET
         public UsdRelationship GetRelationshipAtPath(string relPath)
         {
             var relSdfPath = new SdfPath(relPath);
-            var p = Stage.GetPrimAtPath(relSdfPath.GetPrimPath());
-            if (p == null || !p.IsValid())
-            {
-                return null;
-            }
-            var rel = p.GetRelationship(relSdfPath.GetNameToken());
+            var rel = Stage.GetRelationshipAtPath(relSdfPath);
             if (rel == null || !rel.IsValid())
             {
                 return null;

--- a/package/com.unity.formats.usd/Tests/USD.NET/BasicTests.cs
+++ b/package/com.unity.formats.usd/Tests/USD.NET/BasicTests.cs
@@ -22,13 +22,6 @@ namespace USD.NET.Tests
 {
     class BasicTests : VariabilityTests
     {
-        class MinimalSample : USD.NET.SampleBase
-        {
-            public int number;
-            public int? number2;
-            public USD.NET.Relationship rel;
-        }
-
         class IntrinsicsSample : USD.NET.SampleBase
         {
             public bool bool_;
@@ -222,19 +215,6 @@ namespace USD.NET.Tests
                     floatValue = v;
                 }
             }
-        }
-
-        [Test]
-        public static void SmokeTest()
-        {
-            var sample = new MinimalSample();
-            var sample2 = new MinimalSample();
-
-            sample.number = 42;
-            sample.number2 = null;
-            WriteAndRead(ref sample, ref sample2);
-
-            AssertEqual(sample2.number, sample.number);
         }
 
         void InitIntrinsicSample(ref IntrinsicsSample sample)
@@ -667,54 +647,6 @@ namespace USD.NET.Tests
             WriteAndRead(ref late1, ref late2);
 
             scene.Close();
-        }
-
-        [Test]
-        public static void GetUsdObjectsTest()
-        {
-            var scene = USD.NET.Scene.Create();
-            var sample = new MinimalSample();
-            sample.number = 45;
-            sample.rel = new USD.NET.Relationship("/Foo");
-
-            scene.Write("/Foo", sample);
-
-            Assert.True(scene.GetPrimAtPath("/Foo") != null);
-            Assert.True(scene.GetAttributeAtPath("/Foo.number") != null);
-            Assert.True(scene.GetRelationshipAtPath("/Foo.rel") != null);
-
-            Assert.True(scene.GetPrimAtPath("/Prim/Does/Not/Exist") == null);
-            Assert.True(scene.GetRelationshipAtPath("/Foo.number") == null);
-            Assert.True(scene.GetAttributeAtPath("/Foo.rel") == null);
-        }
-
-        [Test]
-        public static void ReadNonExistingPrimsTest()
-        {
-            var scene = USD.NET.Scene.Create();
-
-            var sample = new MinimalSample();
-            // Read non existing prim, not in the prim map
-            scene.Read<MinimalSample>("/Foo", sample);
-            Assert.True(sample.number == 0);
-            Assert.True(sample.rel == null);
-
-            sample.number = 45;
-            sample.rel = new USD.NET.Relationship("/Foo");
-            scene.Write("/Foo", sample);
-
-            //// Reading the prim adds it the internal prim map
-            var sample2 = new MinimalSample();
-            scene.Read<MinimalSample>("/Foo", sample2);
-            Assert.True(sample.number == sample2.number);
-            Assert.True(sample.rel != null);
-
-            // Reading a non existing prim that is still in the prim map
-            scene.Stage.RemovePrim(new pxr.SdfPath("/Foo"));
-            var sample3 = new MinimalSample();
-            scene.Read<MinimalSample>("/Foo", sample3);
-            Assert.True(sample3.number == 0);
-            Assert.True(sample3.rel == null);
         }
 
         [Test]

--- a/package/com.unity.formats.usd/Tests/USD.NET/SceneTests.cs
+++ b/package/com.unity.formats.usd/Tests/USD.NET/SceneTests.cs
@@ -1,0 +1,112 @@
+using NUnit.Framework;
+using pxr;
+
+namespace USD.NET.Tests
+{
+    class MinimalSample : SampleBase
+    {
+        public int number;
+        public int? number2;
+        public Relationship rel;
+    }
+
+    class SceneTests : UsdTests
+    {
+        MinimalSample sample;
+        Scene scene;
+
+        [SetUp]
+        public void CreateSceneWithMinimalSample()
+        {
+            scene = Scene.Create();
+            sample = new MinimalSample();
+            sample.number = 42;
+            sample.rel = new Relationship("/Foo");
+            scene.Write("/Foo", sample);
+        }
+
+        [Test]
+        public void SmokeTest()
+        {
+            var sample2 = new MinimalSample();
+            sample.number2 = null;
+            scene.Read("/Foo", sample2);
+
+            AssertEqual(sample2.number, sample.number);
+        }
+
+        [Test]
+        public void ReadNonExistingPrimsTest()
+        {
+            var sampleRead = new MinimalSample();
+            // Read non existing prim, not in the prim map
+            scene.Read("/NotFoo", sampleRead);
+            Assert.Zero(sampleRead.number);
+            Assert.Null(sampleRead.rel);
+
+
+            //// Reading the prim adds it in the internal prim map
+            var sampleRead2 = new MinimalSample();
+            scene.Read("/Foo", sampleRead2);
+            Assert.AreEqual(sample.number, sampleRead2.number);
+            Assert.NotNull(sample.rel);
+
+            // Reading a non existing prim that is still in the prim map
+            scene.Stage.RemovePrim(new SdfPath("/Foo"));
+            var sampleRead3 = new MinimalSample();
+            scene.Read("/Foo", sampleRead3);
+            Assert.Zero(sampleRead3.number);
+            Assert.Null(sampleRead3.rel);
+        }
+
+        [Test]
+        public void GetPrimAtPath_ValidPath_Success()
+        {
+            const string path = "/Foo";
+            var prim = scene.GetPrimAtPath(path);
+            Assert.NotNull(prim);
+            Assert.AreEqual(prim, scene.Stage.GetPrimAtPath(new SdfPath(path)));
+        }
+
+        [Test]
+        public void GetPrimAtPath_InvalidPath_ReturnNull()
+        {
+            const string path = "/NotFoo";
+            var prim = scene.GetPrimAtPath(path);
+            Assert.Null(prim);
+        }
+
+        [Test]
+        public void GetAttributeAtPath_ValidPath_Success()
+        {
+            const string path = "/Foo.number";
+            var attr = scene.GetAttributeAtPath(path);
+            Assert.NotNull(attr);
+            Assert.AreEqual(attr, scene.Stage.GetAttributeAtPath(new SdfPath(path)));
+        }
+
+        [TestCase("/Foo.bar", Description = "Invalid attribute")]
+        [TestCase("/NotFoo.bar", Description = "Invalid primitive")]
+        public void GetAttributeAtPath_InvalidPath_ReturnNull(string path)
+        {
+            Assert.Null(scene.GetAttributeAtPath(path));
+        }
+
+        [Test]
+        public void GetRelationshipAtPath_ValidPath_Success()
+        {
+            const string path = "/Foo.rel";
+            var attr = scene.GetRelationshipAtPath(path);
+            Assert.NotNull(attr);
+            Assert.AreEqual(attr, scene.Stage.GetRelationshipAtPath(new SdfPath(path)));
+        }
+
+        [TestCase("/Foo.bar", Description = "Invalid attribute")]
+        [TestCase("/Foo.number", Description = "Not a relationship")]
+        [TestCase("/NotFoo.rel", Description = "Invalid primitive")]
+        public void GetRelationshipAtPath_InvalidPath_ReturnNull(string path)
+        {
+            Assert.Null(scene.GetRelationshipAtPath(path));
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/USD.NET/SceneTests.cs.meta
+++ b/package/com.unity.formats.usd/Tests/USD.NET/SceneTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c68916ed30da400b98ff9c3be51fc509
+timeCreated: 1634246367


### PR DESCRIPTION
Reduce GC alloc of Scene.GetAttributeAtPath and Scene.GetRelationshipAtPath

Remove unnecessary prim sanity check and add better tests.
CLOSE #263 

## Purpose of this PR

**Ticket/Jira #:** https://jira.unity3d.com/browse/USDU-203

This PR reduces GC allocs of Scene.GetAttributeAtPath  and Scene.GetAttributeAtPath from 248B to 112B


## Testing

**Functional Testing status:**

Tests for the Scene class have been moved to a new class. New tests added for GetPrimAtPath, GetAttributeAtPath and GetRelationshipAtPath


## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
