### PR TITLE
Sanitize instanced prims(#USDU-209)

### DIFF
--- a/package/com.unity.formats.usd/CHANGELOG.md
+++ b/package/com.unity.formats.usd/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changes in usd-unitysdk for Unity
 
 ## Unreleased
+### Bug Fixes
+- Fixed an import bug causing instanced primitives not to be sanitized.
+
 ### Changed
 - GC allocs reduced by half for Scene.GetAttributeAtPath and Scene.GetRelationshipAtPath
 

--- a/package/com.unity.formats.usd/Editor/Unity.Formats.USD.Editor.api
+++ b/package/com.unity.formats.usd/Editor/Unity.Formats.USD.Editor.api
@@ -50,3 +50,55 @@ namespace Unity.Formats.USD
         public virtual void OnInspectorGUI();
     }
 }
+
+namespace UnityEditor.Formats.USD.Recorder
+{
+    public class UsdRecorder : UnityEditor.Recorder.GenericRecorder<UnityEditor.Formats.USD.Recorder.UsdRecorderSettings>
+    {
+        public UsdRecorder() {}
+        protected virtual void EndRecording(UnityEditor.Recorder.RecordingSession session);
+        protected virtual void RecordFrame(UnityEditor.Recorder.RecordingSession ctx);
+        protected virtual void SessionCreated(UnityEditor.Recorder.RecordingSession session);
+    }
+
+    public class UsdRecorderInput : UnityEditor.Recorder.RecorderInput
+    {
+        public UsdRecorderInput() {}
+        protected virtual void BeginRecording(UnityEditor.Recorder.RecordingSession session);
+        protected virtual void NewFrameReady(UnityEditor.Recorder.RecordingSession session);
+    }
+
+    public class UsdRecorderInputSettings : UnityEditor.Recorder.RecorderInputSettings
+    {
+        public UnityEngine.GameObject GameObject { get; set; }
+        protected virtual System.Type InputType { get; }
+        public UsdRecorderInputSettings() {}
+        protected virtual bool ValidityCheck(System.Collections.Generic.List<string> errors);
+    }
+
+    [UnityEditor.Recorder.RecorderSettings(typeof(UnityEditor.Formats.USD.Recorder.UsdRecorder), @"USD Clip", @"usd_recorder")] public class UsdRecorderSettings : UnityEditor.Recorder.RecorderSettings
+    {
+        public Unity.Formats.USD.ActiveExportPolicy ActivePolicy { get; set; }
+        public Unity.Formats.USD.BasisTransformation BasisTransformation { get; set; }
+        public UnityEditor.Formats.USD.Recorder.UsdRecorderSettings.Format ExportFormat { get; }
+        public bool ExportMaterials { get; set; }
+        protected virtual string Extension { get; }
+        public virtual System.Collections.Generic.IEnumerable<UnityEditor.Recorder.RecorderInputSettings> InputsSettings { get; }
+        public pxr.UsdInterpolationType InterpolationType { get; set; }
+        public float Scale { get; set; }
+        public UsdRecorderSettings() {}
+        public enum Format
+        {
+            public const UnityEditor.Formats.USD.Recorder.UsdRecorderSettings.Format USD = 0;
+            public const UnityEditor.Formats.USD.Recorder.UsdRecorderSettings.Format USDA = 1;
+            public const UnityEditor.Formats.USD.Recorder.UsdRecorderSettings.Format USDZ = 2;
+            public int value__;
+        }
+    }
+
+    [UnityEditor.CustomEditor(typeof(UnityEditor.Formats.USD.Recorder.UsdRecorderSettings))] public class UsdRecorderSettingsEditor : UnityEditor.Recorder.RecorderEditor
+    {
+        public UsdRecorderSettingsEditor() {}
+        protected virtual void FileTypeAndFormatGUI();
+    }
+}

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/HierarchyBuilder.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/HierarchyBuilder.cs
@@ -272,7 +272,7 @@ namespace Unity.Formats.USD
                         Debug.LogException(new Exception("Error processing " + masterRootPrim.GetPath(), ex));
                     }
 
-                    foreach (var usdPrim in masterRootPrim.GetDescendants())
+                    foreach (var usdPrim in masterRootPrim.GetAllDescendants())
                     {
                         var parentPath = usdPrim.GetPath().GetParentPath();
                         Transform parentXf = null;

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImporter.cs
@@ -763,13 +763,14 @@ namespace Unity.Formats.USD
                     if (importOptions.importTransforms)
                     {
                         Profiler.BeginSample("USD: Build Xforms");
-                        foreach (var pathAndSample in scene.ReadAll<XformSample>(masterRootPath))
+                        foreach (var pathAndSample in scene.ReadAll<SanitizedXformSample>(masterRootPath))
                         {
                             try
                             {
                                 GameObject go = primMap[pathAndSample.path];
                                 NativeImporter.ImportObject(scene, go, scene.GetPrimAtPath(pathAndSample.path),
                                     importOptions);
+                                pathAndSample.sample.Sanitize(scene, importOptions);
                                 XformImporter.BuildXform(pathAndSample.path, pathAndSample.sample, go, importOptions,
                                     scene);
                             }
@@ -780,30 +781,14 @@ namespace Unity.Formats.USD
                             }
                         }
 
-                        foreach (var pathAndSample in scene.ReadAll<XformSample>(masterRootPath))
+                        foreach (var pathAndSample in scene.ReadAll<SanitizedXformSample>(primMap.Skeletons))
                         {
                             try
                             {
                                 GameObject go = primMap[pathAndSample.path];
                                 NativeImporter.ImportObject(scene, go, scene.GetPrimAtPath(pathAndSample.path),
                                     importOptions);
-                                XformImporter.BuildXform(pathAndSample.path, pathAndSample.sample, go, importOptions,
-                                    scene);
-                            }
-                            catch (System.Exception ex)
-                            {
-                                Debug.LogException(
-                                    new ImportException("Error processing xform <" + pathAndSample.path + ">", ex));
-                            }
-                        }
-
-                        foreach (var pathAndSample in scene.ReadAll<XformSample>(primMap.Skeletons))
-                        {
-                            try
-                            {
-                                GameObject go = primMap[pathAndSample.path];
-                                NativeImporter.ImportObject(scene, go, scene.GetPrimAtPath(pathAndSample.path),
-                                    importOptions);
+                                pathAndSample.sample.Sanitize(scene, importOptions);
                                 XformImporter.BuildXform(pathAndSample.path, pathAndSample.sample, go, importOptions,
                                     scene);
                             }
@@ -828,6 +813,7 @@ namespace Unity.Formats.USD
                                 GameObject go = primMap[pathAndSample.path];
                                 NativeImporter.ImportObject(scene, go, scene.GetPrimAtPath(pathAndSample.path),
                                     importOptions);
+                                pathAndSample.sample.Sanitize(scene, importOptions);
                                 XformImporter.BuildXform(pathAndSample.path, pathAndSample.sample, go, importOptions,
                                     scene);
                                 var subsets = MeshImporter.ReadGeomSubsets(scene, pathAndSample.path);
@@ -896,11 +882,12 @@ namespace Unity.Formats.USD
                     if (importOptions.importCameras)
                     {
                         Profiler.BeginSample("USD: Build Cameras");
-                        foreach (var pathAndSample in scene.ReadAll<CameraSample>(masterRootPath))
+                        foreach (var pathAndSample in scene.ReadAll<SanitizedCameraSample>(masterRootPath))
                         {
                             try
                             {
                                 GameObject go = primMap[pathAndSample.path];
+                                pathAndSample.sample.Sanitize(scene, importOptions);
                                 NativeImporter.ImportObject(scene, go, scene.GetPrimAtPath(pathAndSample.path),
                                     importOptions);
                                 XformImporter.BuildXform(pathAndSample.path, pathAndSample.sample, go, importOptions,

--- a/package/com.unity.formats.usd/Tests/Runtime/Data/mesh_instances.usd
+++ b/package/com.unity.formats.usd/Tests/Runtime/Data/mesh_instances.usd
@@ -1,0 +1,53 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+    metersPerUnit = 0.01
+    upAxis = "Y"
+)
+
+def Xform "root" (
+    kind = "component"
+)
+{
+    def Xform "cube_01" (
+        instanceable = true
+        prepend references = </sources/cube>
+    )
+    {
+        double3 xformOp:translate = (2, 0, 2)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Xform "cube_02" (
+        instanceable = true
+        prepend references = </sources/cube>
+    )
+    {
+        double3 xformOp:translate = (4, 0, 4)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Xform "cube_03" (
+        instanceable = true
+        prepend references = </sources/cube>
+    )
+    {
+        double3 xformOp:translate = (6, 0, 6)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+}
+
+over "sources"
+{
+    def Xform "cube"
+    {
+        def Mesh "cube_geo"
+        {
+            uniform bool doubleSided = 1
+            float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+            point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Runtime/Data/mesh_instances.usd.meta
+++ b/package/com.unity.formats.usd/Tests/Runtime/Data/mesh_instances.usd.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c5046ed8700c010469c4c557353bc241
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/USD.NET/StageTests.cs
+++ b/package/com.unity.formats.usd/Tests/USD.NET/StageTests.cs
@@ -333,7 +333,7 @@ namespace USD.NET.Tests
             var allPaths = s.GetAllPathsByType(meshToken, SdfPath.AbsoluteRootPath());
             Assert.AreEqual(2, allPaths.Count);
         }
-        
+
         [Test]
         public void WritingInvalidPrims_ShouldNotCrash()
         {


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** https://jira.unity3d.com/browse/USDU-209

The last release introduced santized samples to sanitize USD prims for loading in Unity. Instanced prims were forgotten and are currently loading unsanitized (no basis conversion, no triangulation, vertex winding change, primvar unroll)

This PR sanitizes the master/instanced prims and add a couple of tests to validate it. 

Before:
![instance_fix_before](https://user-images.githubusercontent.com/2866068/142283577-f7da1af8-86ed-4466-8680-868b575af7a6.PNG)

After:
![instance_fix_after](https://user-images.githubusercontent.com/2866068/142283589-3e2db81f-3c38-4457-afbc-35b6e9a331de.PNG)


## Testing

**Functional Testing status:**

A couple of integration tests to validate that:

- meshes an transforms are sanitized
- meshes are shared between instances

**Performance Testing status:**

N/A

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
Minimal

**Halo Effect:**
Minimal

## Additional information

**Note to reviewers:**

I used https://usd-alab.s3.amazonaws.com/USD_ALab_0730.zip. Before the PR all the meshes and xforms are out of whack. After the scene loads properly. Warning: the payload policy doesn't seem to apply properly (see below), you need to press the Rebuild button.

I noticed a bunch of other bugs: 
* https://jira.unity3d.com/browse/USDU-210
* https://jira.unity3d.com/browse/USDU-212
* https://jira.unity3d.com/browse/USDU-214

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [x] Add entry in CHANGELOG.md _(if applicable)_
