### PR TITLE
Feat: Add UsdTransform2d export support

### DIFF
--- a/package/com.unity.formats.usd/Dependencies/USD.NET.Unity/Shading/UsdPreviewSurface/UsdTransform2dSample.cs
+++ b/package/com.unity.formats.usd/Dependencies/USD.NET.Unity/Shading/UsdPreviewSurface/UsdTransform2dSample.cs
@@ -1,0 +1,56 @@
+// Copyright 2021 Unity Technologies. All rights reserved.
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using UnityEngine;
+
+namespace USD.NET.Unity
+{
+    /// <summary>
+    /// The following is based on the Pixar specification found here:
+    /// https://graphics.pixar.com/usd/release/spec_usdpreviewsurface.html#transform2d
+    /// </summary>
+    [System.Serializable]
+    [UsdSchema("Shader")]
+    public class UsdTransform2dSample : ShaderSample
+    {
+        public UsdTransform2dSample()
+        {
+            id = new pxr.TfToken("UsdTransform2d");
+        }
+
+        /// <summary>
+        /// Name of the primvar to be read from the primitive.
+        /// </summary>
+        [InputParameter("in")]
+        public Connectable<pxr.TfToken> @in = new Connectable<pxr.TfToken>();
+
+        [InputParameter("_Scale")]
+        public Connectable<Vector2> scale = new Connectable<Vector2>(new Vector2(1.0f, 1.0f));
+
+        [InputParameter("_Translation")]
+        public Connectable<Vector2> translation = new Connectable<Vector2>(new Vector2(0.0f, 0.0f));
+
+        [InputParameter("_Rotation")]
+        public Connectable<float> rotation = new Connectable<float>(0.0f);
+
+        public class Outputs : SampleBase
+        {
+            public Vector2? result;
+        }
+
+        [UsdNamespace("outputs")]
+        public Outputs outputs = new Outputs();
+    }
+}

--- a/package/com.unity.formats.usd/Dependencies/USD.NET.Unity/Shading/UsdPreviewSurface/UsdTransform2dSample.cs.meta
+++ b/package/com.unity.formats.usd/Dependencies/USD.NET.Unity/Shading/UsdPreviewSurface/UsdTransform2dSample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb100e57b4f013643b2e911fee95c448
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/ShaderExporterBase.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/ShaderExporterBase.cs
@@ -83,8 +83,11 @@ namespace Unity.Formats.USD
                         // normal needs to be converted if the one on disk isn't really a normal map
                         // (e.g. created from greyscale)
                         UnityEditor.TextureImporter importer =
-                            (UnityEditor.TextureImporter)UnityEditor.AssetImporter.GetAtPath(
-                                UnityEditor.AssetDatabase.GetAssetPath(srcTexture2d));
+                            UnityEditor.AssetImporter.GetAtPath(
+                                UnityEditor.AssetDatabase.GetAssetPath(srcTexture2d)) as UnityEditor.TextureImporter;
+
+                        if (!importer) break;
+
                         if (importer.textureType != UnityEditor.TextureImporterType.NormalMap)
                         {
                             Debug.LogWarning("Texture " + textureName + " is set as NormalMap but isn't marked as such",
@@ -304,15 +307,25 @@ namespace Unity.Formats.USD
                 scene.Write(usdShaderPath + "/uvReader", uvReader);
                 var connectionPath = "/uvReader.outputs:result";
 
-                var textureOffset = material.mainTextureOffset;
-                var textureScale = material.mainTextureScale;
+                var textureOffset = material.GetTextureOffset(textureName);
+                var textureScale = material.GetTextureScale(textureName);
+                var textureRotation = material.HasProperty(textureName + "Rotation") ? Mathf.Rad2Deg * material.GetFloat(textureName + "Rotation") : 0f;
+
+                // Workaround: texture rotation in USDZ rotates around top left corner while glTF rotates around bottom left corner.
+                // Since shaders are built for the latter we need to compensate here.
+                var v = new Vector2(0 * textureScale.x, 1 * textureScale.y);
+                v = Matrix4x4.Rotate(Quaternion.Euler(0, 0, textureRotation)) * new Vector4(v.x, v.y, 0, 1);
+                v.y -= 1 * textureScale.y;
+                textureOffset -= v;
 
                 // export UsdTransform2d, only if non-default offset/scale
-                if(textureOffset != Vector2.zero || textureScale != Vector2.one)
+                if(textureOffset != Vector2.zero || textureScale != Vector2.one || textureRotation != 0)
                 {
                     var usdTransform = new UsdTransform2dSample();
                     usdTransform.scale = new Connectable<Vector2>(textureScale);
                     usdTransform.translation = new Connectable<Vector2>(textureOffset);
+                    if(textureRotation != 0)
+                        usdTransform.rotation = new Connectable<float>(textureRotation);
                     usdTransform.@in.SetConnectedPath(usdShaderPath + "/uvReader.outputs:result");
                     scene.Write(usdShaderPath + "/usdTransform", usdTransform);
                     connectionPath = "/usdTransform.outputs:result";

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/ShaderExporterBase.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/ShaderExporterBase.cs
@@ -311,6 +311,12 @@ namespace Unity.Formats.USD
                 var textureScale = material.GetTextureScale(textureName);
                 var textureRotation = material.HasProperty(textureName + "Rotation") ? Mathf.Rad2Deg * material.GetFloat(textureName + "Rotation") : 0f;
 
+                if (textureOffset == Vector2.zero && textureScale == Vector2.one)
+                {
+                    textureOffset = material.mainTextureOffset;
+                    textureScale = material.mainTextureScale;
+                }
+
                 // Workaround: texture rotation in USDZ rotates around top left corner while glTF rotates around bottom left corner.
                 // Since shaders are built for the latter we need to compensate here.
                 var v = new Vector2(0 * textureScale.x, 1 * textureScale.y);

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/StandardShaderExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/StandardShaderExporter.cs
@@ -301,6 +301,7 @@ namespace Unity.Formats.USD
         {
             Color c;
 
+#if EXPORT_UNITY_SPECIFIC_DATA
             // Export all generic parameter.
             // These are not useful to UsdPreviewSurface, but enable perfect round-tripping.
             surface.unity.shaderName = mat.shader.name;
@@ -333,6 +334,7 @@ namespace Unity.Formats.USD
                         break;
                 }
             }
+#endif
 #endif
 
             if (mat.HasProperty("_MainTex") && mat.GetTexture("_MainTex") != null)


### PR DESCRIPTION
## Purpose of this PR

This PR adds support for UsdPreviewSurface UsdTransform2d export – allowing to export texture offset/tiling to USD and USDZ.
Spec here: https://graphics.pixar.com/usd/release/spec_usdpreviewsurface.html#transform2d

This also works in QuickLook, but it seems that the order of operations is wrongly implemented there – will do a bug report. It's still useful for scale though.

**glTF:**
![image](https://user-images.githubusercontent.com/2693840/171827215-2261de70-91d2-4c13-9df1-e9500f43d5e0.png)

**usdview:**
![image](https://user-images.githubusercontent.com/2693840/171826733-04730ef4-7c82-4076-8791-a5f316416c9e.png)

## Overall Product Risks

**Complexity:**
Low

**Halo Effect:**
Low

## Additional information

**Note to reviewers:**

Currently not implemented for import. Also haven't tested what happens when exporting animated UV offsets, which I think would be outside of the scope of this PR (other samplers also don't fully support animation).

Open questions:
- where/how/if to add test assets