### PR TITLE
Add Samples object to package.json

### DIFF
--- a/package/com.unity.formats.usd/package.json
+++ b/package/com.unity.formats.usd/package.json
@@ -30,5 +30,37 @@
         "url": "ssh://git@github.com:Unity-Technologies/usd-unity-sdk.git"
     },
     "unity": "2019.4",
-    "version": "3.0.0-exp.2"
+    "version": "3.0.0-exp.2",
+    "samples": [
+        {
+            "displayName": "ExportMesh",
+            "description": "Shows how to record a scene to a USD file",
+            "path": "Samples/ExportMesh"
+        },
+        {
+            "displayName": "HelloUsd",
+            "description": "Shows how to write custom data to USD",
+            "path": "Samples/HelloUsd"
+        },
+        {
+            "displayName": "ImportMaterials",
+            "description": "Shows how to import materials from USD into Unity",
+            "path": "Samples/ImportMaterials"
+        },
+        {
+            "displayName": "ImportMesh",
+            "description": "Shows how to import a scene from USD into Unity",
+            "path": "Samples/ImportMesh"
+        },
+        {
+            "displayName": "ImportProcessor",
+            "description": "Shows how to implement pre-import and post-import processors",
+            "path": "Samples/ImportProcessor"
+        },
+        {
+            "displayName": "UsdTimelinePlayable",
+            "description": "Shows how to use the USD integration in Timeline.",
+            "path": "Samples/UsdTimelinePlayable"
+        }
+    ]
 }


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** https://github.com/Unity-Technologies/usd-unity-sdk/issues/319

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->

`Samples` are not displayed within the `PackageManager` under Unity 2021.3 due to a missed configuration step in the `package.json` file:

> 2. Add a [JSON object for each sample](https://docs.unity3d.com/Manual/cus-samples.html#sample-manifest) under the samples array in your package.json manifest file.

## Testing

**Functional Testing status:**

Add package from local and git url.
Expected output shows 'Samples' for user import.

![image](https://user-images.githubusercontent.com/54269136/202448519-f741fc42-eda8-45e8-bcd5-2fc4bbc30df5.png)

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
<!-- (Minimal / Low / Medium / High) -->
Minimal

**Halo Effect:**
<!-- (Minimal / Low / Medium / High) -->
Low

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->
The Unity documentation states that the `samples` object should be present in the `package.json` https://docs.unity3d.com/Manual/cus-samples.html

