### PR TITLE
Fixed USDU-173 - scene not marked dirty after changing load payload flag

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
@@ -222,7 +222,12 @@ namespace Unity.Formats.USD
 #if UNITY_EDITOR
             if (!UnityEditor.EditorUtility.IsPersistent(root))
             {
+#if UNITY_2021_2_OR_NEWER
+                var prefabStage = UnityEditor.SceneManagement.PrefabStageUtility.GetPrefabStage(root);
+#else
                 var prefabStage = UnityEditor.Experimental.SceneManagement.PrefabStageUtility.GetPrefabStage(root);
+#endif
+
                 if (prefabStage != null)
                 {
                     if (!UnityEditor.PrefabUtility.IsPartOfPrefabInstance(root))

--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdPayload.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdPayload.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using UnityEditor;
-using UnityEditor.SceneManagement;
 using UnityEngine;
 
 namespace Unity.Formats.USD

--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdPayload.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdPayload.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using UnityEditor;
+using UnityEditor.SceneManagement;
 using UnityEngine;
 
 namespace Unity.Formats.USD
@@ -19,10 +21,13 @@ namespace Unity.Formats.USD
     [ExecuteInEditMode]
     public class UsdPayload : MonoBehaviour
     {
-        [SerializeField] private bool m_isLoaded = true;
+        [SerializeField]
+        private bool m_isLoaded = true;
 
         // Variable used to track dirty load state.
-        [SerializeField][HideInInspector] private bool m_wasLoaded = true;
+        [SerializeField]
+        [HideInInspector]
+        private bool m_wasLoaded = true;
 
         /// <summary>
         /// Returns true of the prim is currently loaded. Note that this will return the currently
@@ -70,6 +75,10 @@ namespace Unity.Formats.USD
             }
 
             m_wasLoaded = m_isLoaded;
+
+#if UNITY_EDITOR
+            EditorUtility.SetDirty(this);
+#endif
 
             var stageRoot = transform.GetComponentInParent<UsdAsset>();
             stageRoot.SetPayloadState(this.gameObject, m_isLoaded);

--- a/package/com.unity.formats.usd/Tests/Editor/CleanTestEnvironment.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/CleanTestEnvironment.cs
@@ -1,3 +1,17 @@
+// Copyright 2022 Unity Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using NUnit.Framework;
 
 using UnityEditor;

--- a/package/com.unity.formats.usd/Tests/Editor/CleanTestEnvironment.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/CleanTestEnvironment.cs
@@ -1,0 +1,41 @@
+using NUnit.Framework;
+
+using UnityEditor;
+using UnityEngine.SceneManagement;
+using UnityEditor.SceneManagement;
+
+using System.IO;
+
+public abstract class CleanTestEnvironment
+{
+    protected Scene m_UnityScene;
+    protected string ArtifactsDirectory = "Assets/Artifacts/";
+
+    [SetUp]
+    public void CreateTestArtifactsAndStreamingAssetsDirectories()
+    {
+        m_UnityScene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene);
+
+        if (!Directory.Exists(ArtifactsDirectory))
+        {
+            Directory.CreateDirectory(ArtifactsDirectory);
+            AssetDatabase.Refresh();
+        }
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(ArtifactsDirectory))
+        {
+            FileUtil.DeleteFileOrDirectory(ArtifactsDirectory);
+            FileUtil.DeleteFileOrDirectory(ArtifactsDirectory.TrimEnd('/') + ".meta");
+            AssetDatabase.Refresh();
+        }
+    }
+
+    public string GetUnityScenePath(string sceneName)
+    {
+        return ArtifactsDirectory + sceneName + ".unity";
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Editor/CleanTestEnvironment.cs.meta
+++ b/package/com.unity.formats.usd/Tests/Editor/CleanTestEnvironment.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5a278508421f324a85cb1d799c55dbb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/Editor/USDPayloadComponentTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/USDPayloadComponentTests.cs
@@ -1,3 +1,17 @@
+// Copyright 2022 Unity Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEditor.SceneManagement;
@@ -195,7 +209,7 @@ namespace Unity.Formats.USD.Tests
         }
 
         [UnityTest]
-        public IEnumerator ChangingUsdPayloadSateFromUnloadedToLoaded_MarksSceneDirty()
+        public IEnumerator ChangingUsdPayloadStateFromUnloadedToLoaded_MarksSceneDirty()
         {
             m_usdAsset.m_payloadPolicy = PayloadPolicy.DontLoadPayloads;
             m_usdAsset.Reload(forceRebuild: true);
@@ -212,7 +226,7 @@ namespace Unity.Formats.USD.Tests
         }
 
         [UnityTest]
-        public IEnumerator ChangingUsdPayloadSateFromLoadedToUnloaded_MarksSceneDirty()
+        public IEnumerator ChangingUsdPayloadStateFromLoadedToUnloaded_MarksSceneDirty()
         {
             m_usdAsset.m_payloadPolicy = PayloadPolicy.LoadAll;
             m_usdAsset.Reload(forceRebuild: true);


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:**
https://jira.unity3d.com/browse/USDU-173: Scene is not marked dirty when loading a payload

## Testing

**Functional Testing status:**
Manual tests and automated tests for loading/unloading payloads

**Performance Testing status:**
N/A

## Overall Product Risks

**Complexity:**
Minimal

**Halo Effect:**
Minimal

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
