### PR TITLE
[USDU-274] Adds new test cases for ImportHelper functions

### DIFF
--- a/package/com.unity.formats.usd/Tests/Common/BaseFixture.cs
+++ b/package/com.unity.formats.usd/Tests/Common/BaseFixture.cs
@@ -16,9 +16,10 @@ using System.IO;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEditor;
-
 using USDScene = USD.NET.Scene;
 using UnityScene = UnityEngine.SceneManagement.Scene;
+using USD.NET;
+using USD.NET.Unity;
 
 namespace Unity.Formats.USD.Tests
 {
@@ -74,13 +75,23 @@ namespace Unity.Formats.USD.Tests
             return Path.Combine(ArtifactsDirectoryRelativePath, prefabName);
         }
 
-        public string CreateTmpUsdFile(string fileName)
+        public string CreateTmpUsdFile(string fileName = "tempUsd.usda")
         {
             var usdScenePath = GetUSDScenePath(fileName);
             var scene = USDScene.Create(usdScenePath);
             scene.Save();
             scene.Close();
             return usdScenePath;
+        }
+
+        public Scene CreateTestUsdScene(string fileName = "testUsd.usda")
+        {
+            var dummyUsdPath = CreateTmpUsdFile(fileName);
+            var scene = ImportHelpers.InitForOpen(dummyUsdPath);
+            scene.Write("/root", new XformSample());
+            scene.Write("/root/sphere", new SphereSample());
+            scene.Save();
+            return scene;
         }
 
         [SetUp]

--- a/package/com.unity.formats.usd/Tests/Editor/ImportHelpersTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/ImportHelpersTests.cs
@@ -4,95 +4,127 @@ using UnityEditor;
 using UnityEngine;
 using USD.NET;
 using USD.NET.Unity;
+using System.Linq;
 using Object = UnityEngine.Object;
+using System;
 
 namespace Unity.Formats.USD.Tests
 {
     public class ImportHelpersTests : BaseFixtureEditor
     {
-        Scene CreateTestAsset(string fileName)
+        [Test]
+        public void ImportAsPrefabTest_SceneClosedAfterImport()
         {
-            var dummyUsdPath = CreateTmpUsdFile(fileName);
-            var scene = ImportHelpers.InitForOpen(dummyUsdPath);
-            scene.Write("/root", new XformSample());
-            scene.Write("/root/sphere", new SphereSample());
-            scene.Save();
-            return scene;
+            var scene = CreateTestUsdScene();
+            ImportHelpers.ImportAsPrefab(scene, GetPrefabPath());
+            Assert.IsNull(scene.Stage, "Scene was not closed after import.");
+        }
+
+        [Test]
+        public void ImportAsTimelineClipTest_SceneClosedAfterImport()
+        {
+            var scene = CreateTestUsdScene();
+            ImportHelpers.ImportAsTimelineClip(scene, GetPrefabPath());
+            Assert.IsNull(scene.Stage, "Scene was not closed after import.");
+        }
+
+        [Test]
+        public void ImportAsPrefabTest_ImportClosedScene_Error()
+        {
+            var scene = CreateTestUsdScene();
+            scene.Close();
+            Assert.Throws<System.NullReferenceException>(() => ImportHelpers.ImportAsPrefab(scene, GetPrefabPath()));
+        }
+
+        [Test]
+        public void ImportAsTimelineClipTest_ImportClosedScene_Error()
+        {
+            var scene = CreateTestUsdScene();
+            scene.Close();
+            Assert.Throws<System.NullReferenceException>(() => ImportHelpers.ImportAsTimelineClip(scene, GetPrefabPath()));
         }
 
         [Test]
         public void ImportAsPrefabTest_ContentOk()
         {
-            var scene = CreateTestAsset("dummyUsd.usda");
+            var scene = CreateTestUsdScene();
             var assetPath = ImportHelpers.ImportAsPrefab(scene, GetPrefabPath());
-            Assert.IsNull(scene.Stage, "Scene was not closed after import.");
 
             Assert.IsTrue(File.Exists(assetPath));
-            var allObjects = AssetDatabase.LoadAllAssetsAtPath(assetPath);
-            Assert.NotZero(allObjects.Length);
-            bool playableAssetFound = false;
-            int goCount = 0;
-            int materialCount = 0;
-            foreach (Object thisObject in allObjects)
-            {
-                string myType = thisObject.GetType().Name;
-                if (myType == "UsdPlayableAsset")
-                {
-                    playableAssetFound = true;
-                }
-                else if (myType == "GameObject")
-                {
-                    goCount += 1;
-                }
-                else if (myType == "Material")
-                {
-                    materialCount += 1;
-                }
-            }
+            var usdAsObjects = AssetDatabase.LoadAllAssetsAtPath(assetPath);
 
-            Assert.IsTrue(playableAssetFound, "No PlayableAssset was found in the prefab.");
-            Assert.AreEqual(2, goCount, "Wrong GameObjects count in the prefab.");
-            // The 3 default materials + 1 material per meshRender
-            Assert.AreEqual(4, materialCount, "Wrong Materials count in the prefab");
+            // ExpectedGameObjectCount: The Root GameObject + Sphere GameObject added
+            // ExpectedPrimSourceCount: Root Source + Sphere Source
+            // ExpectedMaterialCount: The 3 default materials + 1 material from Sphere meshRender
+            EditorImportAssert.IsValidImport(usdAsObjects, expectedGameObjectCount: 2, expectedPrimSourceCount: 2, expectedMaterialCount: 4);
         }
 
         [Test]
         public void ImportAsTimelineClipTest_ContentOk()
         {
             // Import as timeline clip should not create a hierarchy, only the root and the playable
-            var scene = CreateTestAsset("dummyUsd.usda");
+            var scene = CreateTestUsdScene();
             var assetPath = ImportHelpers.ImportAsTimelineClip(scene, GetPrefabPath());
-            Assert.IsNull(scene.Stage, "Scene was not closed after import.");
 
             Assert.IsTrue(File.Exists(assetPath));
-            var allObjects = AssetDatabase.LoadAllAssetsAtPath(assetPath);
-            Assert.NotZero(allObjects.Length);
+            var usdAsObjects = AssetDatabase.LoadAllAssetsAtPath(assetPath);
+
+            // ExpectedGameObjectCount: The Root GameObject
+            // ExpectedPrimSourceCount: 0 TODO: Shouldnt there be a prim source object for the root object?
+            // ExpectedMaterialCount: The 3 default materials
+            EditorImportAssert.IsValidImport(usdAsObjects, expectedGameObjectCount: 1, expectedPrimSourceCount: 0, expectedMaterialCount: 3);
+        }
+    }
+
+    public static class EditorImportAssert
+    {
+        enum UsdPartType
+        {
+            UsdPlayableAsset = 0,
+            GameObject = 1,
+            Material = 2,
+            UsdPrimSource = 3
+        }
+
+
+        public static void IsValidImport(Object[] usdAsObjects, int expectedGameObjectCount, int expectedPrimSourceCount, int expectedMaterialCount)
+        {
+            Assert.NotZero(usdAsObjects.Length);
+
             bool playableAssetFound = false;
-            int goCount = 0;
+            int gameObjectCount = 0;
             int materialCount = 0;
-            foreach (Object thisObject in allObjects)
+            int usdPrimSourceCount = 0;
+
+            foreach (Object usdPart in usdAsObjects)
             {
-                Debug.Log(thisObject.name);
-                Debug.Log(thisObject.GetType().Name);
-                string myType = thisObject.GetType().Name;
-                if (myType == "UsdPlayableAsset")
+                switch (usdPart.GetType().Name)
                 {
-                    playableAssetFound = true;
-                }
-                else if (myType == "GameObject")
-                {
-                    goCount += 1;
-                }
-                else if (myType == "Material")
-                {
-                    materialCount += 1;
+                    case nameof(UsdPartType.UsdPlayableAsset):
+                        playableAssetFound = true;
+                        break;
+
+                    case nameof(UsdPartType.GameObject):
+                        gameObjectCount++;
+                        break;
+
+                    case nameof(UsdPartType.Material):
+                        materialCount++;
+                        break;
+
+                    case nameof(UsdPartType.UsdPrimSource):
+                        usdPrimSourceCount++;
+                        break;
+
+                    default:
+                        break;
                 }
             }
 
             Assert.IsTrue(playableAssetFound, "No PlayableAssset was found in the prefab.");
-            Assert.AreEqual(1, goCount, "Wrong GameObjects count in the prefab.");
-            // Only 3 default materials and no meshRenderer
-            Assert.AreEqual(3, materialCount, "Wrong Materials count in the prefab");
+            Assert.AreEqual(expectedGameObjectCount, gameObjectCount, "Wrong GameObjects count in the prefab.");
+            Assert.AreEqual(expectedPrimSourceCount, usdPrimSourceCount, "Wrong USD Prim Source object in the prefab");
+            Assert.AreEqual(expectedMaterialCount, materialCount, "Wrong Materials count in the prefab");
         }
     }
 }

--- a/package/com.unity.formats.usd/Tests/Editor/ImportHelpersTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/ImportHelpersTests.cs
@@ -12,43 +12,46 @@ namespace Unity.Formats.USD.Tests
 {
     public class ImportHelpersTests : BaseFixtureEditor
     {
+        Scene m_scene;
+
+        [SetUp]
+        public void CreateTestScene()
+        {
+            m_scene = CreateTestUsdScene();
+        }
+
         [Test]
         public void ImportAsPrefabTest_SceneClosedAfterImport()
         {
-            var scene = CreateTestUsdScene();
-            ImportHelpers.ImportAsPrefab(scene, GetPrefabPath());
-            Assert.IsNull(scene.Stage, "Scene was not closed after import.");
+            ImportHelpers.ImportAsPrefab(m_scene, GetPrefabPath());
+            Assert.IsNull(m_scene.Stage, "Scene was not closed after import.");
         }
 
         [Test]
         public void ImportAsTimelineClipTest_SceneClosedAfterImport()
         {
-            var scene = CreateTestUsdScene();
-            ImportHelpers.ImportAsTimelineClip(scene, GetPrefabPath());
-            Assert.IsNull(scene.Stage, "Scene was not closed after import.");
+            ImportHelpers.ImportAsTimelineClip(m_scene, GetPrefabPath());
+            Assert.IsNull(m_scene.Stage, "Scene was not closed after import.");
         }
 
         [Test]
         public void ImportAsPrefabTest_ImportClosedScene_Error()
         {
-            var scene = CreateTestUsdScene();
-            scene.Close();
-            Assert.Throws<System.NullReferenceException>(() => ImportHelpers.ImportAsPrefab(scene, GetPrefabPath()));
+            m_scene.Close();
+            Assert.Throws<System.NullReferenceException>(() => ImportHelpers.ImportAsPrefab(m_scene, GetPrefabPath()));
         }
 
         [Test]
         public void ImportAsTimelineClipTest_ImportClosedScene_Error()
         {
-            var scene = CreateTestUsdScene();
-            scene.Close();
-            Assert.Throws<System.NullReferenceException>(() => ImportHelpers.ImportAsTimelineClip(scene, GetPrefabPath()));
+            m_scene.Close();
+            Assert.Throws<System.NullReferenceException>(() => ImportHelpers.ImportAsTimelineClip(m_scene, GetPrefabPath()));
         }
 
         [Test]
         public void ImportAsPrefabTest_ContentOk()
         {
-            var scene = CreateTestUsdScene();
-            var assetPath = ImportHelpers.ImportAsPrefab(scene, GetPrefabPath());
+            var assetPath = ImportHelpers.ImportAsPrefab(m_scene, GetPrefabPath());
 
             Assert.IsTrue(File.Exists(assetPath));
             var usdAsObjects = AssetDatabase.LoadAllAssetsAtPath(assetPath);
@@ -63,8 +66,7 @@ namespace Unity.Formats.USD.Tests
         public void ImportAsTimelineClipTest_ContentOk()
         {
             // Import as timeline clip should not create a hierarchy, only the root and the playable
-            var scene = CreateTestUsdScene();
-            var assetPath = ImportHelpers.ImportAsTimelineClip(scene, GetPrefabPath());
+            var assetPath = ImportHelpers.ImportAsTimelineClip(m_scene, GetPrefabPath());
 
             Assert.IsTrue(File.Exists(assetPath));
             var usdAsObjects = AssetDatabase.LoadAllAssetsAtPath(assetPath);
@@ -78,7 +80,7 @@ namespace Unity.Formats.USD.Tests
 
     public static class EditorImportAssert
     {
-        enum UsdPartType
+        enum ObjectTypeName
         {
             UsdPlayableAsset = 0,
             GameObject = 1,
@@ -96,23 +98,23 @@ namespace Unity.Formats.USD.Tests
             int materialCount = 0;
             int usdPrimSourceCount = 0;
 
-            foreach (Object usdPart in usdAsObjects)
+            foreach (Object childObject in usdAsObjects)
             {
-                switch (usdPart.GetType().Name)
+                switch (childObject.GetType().Name)
                 {
-                    case nameof(UsdPartType.UsdPlayableAsset):
+                    case nameof(ObjectTypeName.UsdPlayableAsset):
                         playableAssetFound = true;
                         break;
 
-                    case nameof(UsdPartType.GameObject):
+                    case nameof(ObjectTypeName.GameObject):
                         gameObjectCount++;
                         break;
 
-                    case nameof(UsdPartType.Material):
+                    case nameof(ObjectTypeName.Material):
                         materialCount++;
                         break;
 
-                    case nameof(UsdPartType.UsdPrimSource):
+                    case nameof(ObjectTypeName.UsdPrimSource):
                         usdPrimSourceCount++;
                         break;
 
@@ -123,7 +125,7 @@ namespace Unity.Formats.USD.Tests
 
             Assert.IsTrue(playableAssetFound, "No PlayableAssset was found in the prefab.");
             Assert.AreEqual(expectedGameObjectCount, gameObjectCount, "Wrong GameObjects count in the prefab.");
-            Assert.AreEqual(expectedPrimSourceCount, usdPrimSourceCount, "Wrong USD Prim Source object in the prefab");
+            Assert.AreEqual(expectedPrimSourceCount, usdPrimSourceCount, "Wrong USD Prim Source object count in the prefab");
             Assert.AreEqual(expectedMaterialCount, materialCount, "Wrong Materials count in the prefab");
         }
     }

--- a/package/com.unity.formats.usd/Tests/Editor/ImportHelpersTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/ImportHelpersTests.cs
@@ -76,6 +76,12 @@ namespace Unity.Formats.USD.Tests
             // ExpectedMaterialCount: The 3 default materials
             EditorImportAssert.IsValidImport(usdAsObjects, expectedGameObjectCount: 1, expectedPrimSourceCount: 0, expectedMaterialCount: 3);
         }
+
+        [TearDown]
+        public void ClearTestScene()
+        {
+            m_scene = null;
+        }
     }
 
     public static class EditorImportAssert

--- a/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs
@@ -48,7 +48,7 @@ namespace Unity.Formats.USD.Tests
         [Test]
         public void ExportGameObjects_NullScene()
         {
-            var filePath = CreateTmpUsdFile("dummyUsd.usda");
+            var filePath = CreateTmpUsdFile();
             var scene = Scene.Open(filePath);
             scene.Close();
             var fileInfoBefore = new FileInfo(filePath);
@@ -64,7 +64,7 @@ namespace Unity.Formats.USD.Tests
         [Test]
         public void ExportGameObjects_EmptyList()
         {
-            var filePath = CreateTmpUsdFile("dummyUsd.usda");
+            var filePath = CreateTmpUsdFile();
             var scene = Scene.Open(filePath);
             var fileInfoBefore = new FileInfo(filePath);
             Assert.DoesNotThrow(delegate ()
@@ -79,7 +79,7 @@ namespace Unity.Formats.USD.Tests
         [Test]
         public void ExportGameObjects_InvalidGO()
         {
-            var filePath = CreateTmpUsdFile("dummyUsd.usda");
+            var filePath = CreateTmpUsdFile();
             var scene = Scene.Open(filePath);
             Assert.DoesNotThrow(delegate ()
             {
@@ -92,7 +92,7 @@ namespace Unity.Formats.USD.Tests
         [Test]
         public void ExportGameObjects_ValidGO()
         {
-            var filePath = CreateTmpUsdFile("dummyUsd.usda");
+            var filePath = CreateTmpUsdFile();
             var scene = Scene.Open(filePath);
             ExportHelpers.ExportGameObjects(new[] { new GameObject("test") }, scene, BasisTransformation.SlowAndSafe);
             scene = Scene.Open(filePath);
@@ -105,7 +105,7 @@ namespace Unity.Formats.USD.Tests
         [Test]
         public void ExportGameObjects_SceneClosedAfterExport()
         {
-            var filePath = CreateTmpUsdFile("dummyUsd.usda");
+            var filePath = CreateTmpUsdFile();
             var scene = Scene.Open(filePath);
             ExportHelpers.ExportGameObjects(new[] { new GameObject("test") }, scene, BasisTransformation.SlowAndSafe);
             Assert.IsNull(scene.Stage);

--- a/package/com.unity.formats.usd/Tests/Runtime/ImportHelpersTests.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/ImportHelpersTests.cs
@@ -3,26 +3,18 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using USD.NET.Unity;
-using Scene = USD.NET.Scene;
+using System.Collections.Generic;
+using USD.NET;
+using System.Linq;
 
 namespace Unity.Formats.USD.Tests
 {
     public class ImportHelpersTests : BaseFixtureRuntime
     {
-        Scene CreateTmpUsdWithData(string fileName)
-        {
-            var dummyUsdPath = CreateTmpUsdFile(fileName);
-            var scene = ImportHelpers.InitForOpen(dummyUsdPath);
-            scene.Write("/root", new XformSample());
-            scene.Write("/root/sphere", new SphereSample());
-            scene.Save();
-            return scene;
-        }
-
         [Test]
         public void InitForOpenTest_ValidPath_Succeeds()
         {
-            var dummyUsdPath = CreateTmpUsdFile("dummyUsd.usda");
+            var dummyUsdPath = CreateTmpUsdFile();
             var scene = ImportHelpers.InitForOpen(dummyUsdPath);
             Assert.NotNull(scene);
             Assert.NotNull(scene.Stage);
@@ -48,7 +40,7 @@ namespace Unity.Formats.USD.Tests
         [Test]
         public void ImportAsGameObjects_ImportAtRoot()
         {
-            var scene = CreateTmpUsdWithData("dummyUsd.usda");
+            var scene = CreateTestUsdScene();
             var root = ImportHelpers.ImportSceneAsGameObject(scene);
             bool usdRootIsRoot = Array.Find(SceneManager.GetActiveScene().GetRootGameObjects(), r => r == root);
             Assert.IsTrue(usdRootIsRoot, "UsdAsset GameObject is not a root GameObject.");
@@ -58,7 +50,7 @@ namespace Unity.Formats.USD.Tests
         public void ImportAsGameObjects_ImportUnderParent()
         {
             var root = new GameObject("thisIsTheRoot");
-            var scene = CreateTmpUsdWithData("dummyUsd.usda");
+            var scene = CreateTestUsdScene();
             var usdRoot = ImportHelpers.ImportSceneAsGameObject(scene, root);
             Assert.AreEqual(root.transform, usdRoot.transform.root, "UsdAsset is not a children of the given parent.");
         }
@@ -66,16 +58,15 @@ namespace Unity.Formats.USD.Tests
         [Test]
         public void ImportAsGameObjects_SceneClosedAfterImport()
         {
-            var scene = CreateTmpUsdWithData("dummyUsd.usda");
-            var root = ImportHelpers.ImportSceneAsGameObject(scene);
+            var scene = CreateTestUsdScene();
+            ImportHelpers.ImportSceneAsGameObject(scene);
             Assert.IsNull(scene.Stage, "Scene was not closed after import.");
         }
 
         [Test]
         public void ImportAsGameObjects_ImportClosedScene_LogsError()
         {
-            var rootGOsBefore = SceneManager.GetActiveScene().GetRootGameObjects();
-            var scene = CreateTmpUsdWithData("dummyUsd.usda");
+            var scene = CreateTestUsdScene();
             scene.Close();
             var root = ImportHelpers.ImportSceneAsGameObject(scene);
             Assert.IsNull(root);
@@ -83,9 +74,47 @@ namespace Unity.Formats.USD.Tests
         }
 
         [Test]
-        [Ignore("TODO")]
-        public void ImportAsGameObjects_CleanupAfterError()
+        public void ImportAsGameObjects_CleanupAfterErrorAtRoot()
         {
+            var scenePath = CreateTmpUsdFile();
+            var scene = ImportHelpers.InitForOpen(scenePath);
+            scene.Close();
+
+            // This will cause an error as scene is closed
+            var usdObject = ImportHelpers.ImportSceneAsGameObject(scene);
+
+            var rootGameObjects = SceneManager.GetActiveScene().GetRootGameObjects();
+            Assert.IsEmpty(rootGameObjects.Where(o => o == usdObject), "UsdAsset GameObject was not cleaned up after error at root");
+            UnityEngine.TestTools.LogAssert.Expect(LogType.Error, "The USD Scene needs to be opened before being imported.");
+        }
+
+        [Test]
+        public void ImportAsGameObjects_CleanupAfterErrorUnderParent()
+        {
+            var parent = new GameObject();
+            var scenePath = CreateTmpUsdFile();
+            var scene = ImportHelpers.InitForOpen(scenePath);
+            scene.Close();
+
+            // This will cause an error as scene is closed
+            ImportHelpers.ImportSceneAsGameObject(scene, parent);
+
+            Assert.IsTrue(parent.transform.childCount == 0, "UsdAsset GameObject was not cleaned up after error under parent");
+            UnityEngine.TestTools.LogAssert.Expect(LogType.Error, "The USD Scene needs to be opened before being imported.");
+        }
+
+        [Test]
+        public void ImportAsGameObjects_UnderInactiveParent()
+        {
+            var parent = new GameObject();
+            var scenePath = CreateTmpUsdFile();
+            var scene = ImportHelpers.InitForOpen(scenePath);
+
+            parent.SetActive(false);
+            var usdObject = ImportHelpers.ImportSceneAsGameObject(scene, parent);
+
+            Assert.IsFalse(usdObject.activeInHierarchy);
+            Assert.IsTrue(usdObject.activeSelf, "The USD Scene is self-inactive when imported under an inactive parent");
         }
     }
 }

--- a/package/com.unity.formats.usd/Tests/USD.NET/SceneTests.cs
+++ b/package/com.unity.formats.usd/Tests/USD.NET/SceneTests.cs
@@ -113,7 +113,7 @@ namespace USD.NET.Tests
         [TestCase("invalidPath", Description = "Invalid path value")]
         [TestCase("", Description = "Empty path value")]
         [TestCase("../sibling", Description = "Relative path value")]
-        public void WriteInvalidPathDataToScene(string path)
+        public void WritePathToSceneFile_WithInvalidPath_ThrowsException(string path)
         {
             scene = Scene.Create();
             Assert.Throws<System.Exception>(() => scene.Write(path, new SampleBase()));

--- a/package/com.unity.formats.usd/Tests/USD.NET/SceneTests.cs
+++ b/package/com.unity.formats.usd/Tests/USD.NET/SceneTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using pxr;
+using UnityEngine;
 
 namespace USD.NET.Tests
 {
@@ -107,6 +108,16 @@ namespace USD.NET.Tests
         public void GetRelationshipAtPath_InvalidPath_ReturnNull(string path)
         {
             Assert.Null(scene.GetRelationshipAtPath(path));
+        }
+
+        [TestCase("invalidPath", Description = "Invalid path value")]
+        [TestCase("", Description = "Empty path value")]
+        [TestCase("../sibling", Description = "Relative path value")]
+        public void WriteInvalidPathDataToScene(string path)
+        {
+            scene = Scene.Create();
+            Assert.Throws<System.Exception>(() => scene.Write(path, new SampleBase()));
+            UnityEngine.TestTools.LogAssert.Expect(LogType.Exception, string.Format("ApplicationException: USD ERROR: Path must be an absolute path: <{0}>", path));
         }
     }
 }


### PR DESCRIPTION
## Purpose of this PR
**Ticket/Jira #: https://jira.unity3d.com/browse/USDU-274**

Adds new test cases for functions within ImportHelper.cs script to increase coverage and to act as an onboarding task for @lee-aandrew 


## Testing

**Functional Testing status:**
N/A

**Performance Testing status:**
N/A

## Overall Product Risks
N/A

**Complexity:**
1

**Halo Effect:**
1

## Additional information

**Note to reviewers:**
Not sure if this is a bug or a intended way of doing things, but USD.Scene.Write, when given an object of type Parent Class, it will not write anything
For example:

SampleBase testArray[] { SphereSample sphere1, SphereSample sphere2 } // SampleBase is the root parent of SphereSample
Scene.Write("/root/sphere" testArray[0])

The Write in this case would not write anything to the scene
