### PR TITLE
[USDU-249] Adds test case for InitUSD

### DIFF
--- a/package/com.unity.formats.usd/Tests/Editor/InitUsdTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/InitUsdTests.cs
@@ -1,0 +1,73 @@
+using System.Collections;
+using System.IO;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+using USD.NET;
+using USD.NET.Unity;
+using System.Reflection;
+using Unity.Formats.USD;
+using System.Runtime.CompilerServices;
+
+public class InitUsdTests
+{
+    [Test]
+    [Ignore("[USDU-249]")]
+    public void SetupUsdPath_InvalidPath_Error()
+    {
+        // SetupUsdPath function is a private function
+        var setUpMethod = GetMethod("SetupUsdPath");
+
+        try
+        {
+            setUpMethod.Invoke(null, new object[] { "\\NonExisting\\Path\\" });
+        }
+        catch (TargetInvocationException e)
+        {
+            Assert.AreEqual(e.InnerException.GetType(), typeof(FileNotFoundException));
+            return;
+        }
+
+        Assert.Fail("Exception was expected but none was thrown");
+    }
+
+    [Test]
+    public void SetupUsdPath_EmptyPath_Error()
+    {
+        // SetupUsdPath function is a private function
+        var setUpMethod = GetMethod("SetupUsdPath");
+
+        try
+        {
+            setUpMethod.Invoke(null, new object[] { "" });
+        }
+        catch (TargetInvocationException e)
+        {
+            Assert.AreEqual(e.InnerException.GetType(), typeof(System.ArgumentException));
+            return;
+        }
+
+        Assert.Fail("Exception was expected but none was thrown");
+    }
+
+    [Test]
+    public void InitUsd_Initialize()
+    {
+        // Reset 'm_usdInitialized' for accurate testing
+        var isUsdInitialized = typeof(InitUsd).GetField("m_usdInitialized", (BindingFlags.Static | BindingFlags.NonPublic));
+        isUsdInitialized.SetValue(null, false);
+
+        Assert.True(InitUsd.Initialize());
+    }
+
+    private MethodInfo GetMethod(string methodName)
+    {
+        var method = typeof(InitUsd).GetMethod(methodName, (BindingFlags.NonPublic | BindingFlags.Static));
+
+        if (method == null)
+            Assert.Fail(string.Format("{0} method not found", methodName));
+
+        return method;
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Editor/InitUsdTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/InitUsdTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using NUnit.Framework;
 using System.Reflection;
 using Unity.Formats.USD;
+using UnityEngine;
 
 public class InitUsdTests
 {
@@ -9,20 +10,14 @@ public class InitUsdTests
     [Ignore("[USDU-249]")]
     public void SetupUsdPath_InvalidPath_Error()
     {
+        var invalidFilePath = "\\NonExisting\\Path\\";
+
         // SetupUsdPath function is a private function
         var setUpMethod = GetMethod("SetupUsdPath");
 
-        try
-        {
-            setUpMethod.Invoke(null, new object[] { "\\NonExisting\\Path\\" });
-        }
-        catch (TargetInvocationException e)
-        {
-            Assert.AreEqual(e.InnerException.GetType(), typeof(FileNotFoundException));
-            return;
-        }
-
-        Assert.Fail("Exception was expected but none was thrown");
+        var expectedError = Assert.Throws<TargetInvocationException>(() => setUpMethod.Invoke(null, new object[] { invalidFilePath }), "Error was expected but not thrown");
+        Assert.IsInstanceOf<FileNotFoundException>(expectedError.InnerException);
+        Assert.AreEqual(string.Format("Could not find file '{0}'.", invalidFilePath), expectedError.InnerException.Message, "Unexpected error message was given");
     }
 
     [Test]
@@ -31,17 +26,9 @@ public class InitUsdTests
         // SetupUsdPath function is a private function
         var setUpMethod = GetMethod("SetupUsdPath");
 
-        try
-        {
-            setUpMethod.Invoke(null, new object[] { "" });
-        }
-        catch (TargetInvocationException e)
-        {
-            Assert.AreEqual(e.InnerException.GetType(), typeof(System.ArgumentException));
-            return;
-        }
-
-        Assert.Fail("Exception was expected but none was thrown");
+        var expectedError = Assert.Throws<TargetInvocationException>(() => setUpMethod.Invoke(null, new object[] { "" }), "Error was expected but not thrown");
+        Assert.IsInstanceOf<System.ArgumentException>(expectedError.InnerException);
+        Assert.AreEqual("The specified path is not of a legal form (empty).", expectedError.InnerException.Message, "Unexpected error message was given");
     }
 
     [Test]
@@ -50,7 +37,7 @@ public class InitUsdTests
         // Reset 'm_usdInitialized' for accurate testing
         ResetInitUsd();
 
-        Assert.True(InitUsd.Initialize());
+        Assert.True(InitUsd.Initialize(), "USD Initialize failed");
     }
 
     [TearDown]

--- a/package/com.unity.formats.usd/Tests/Editor/InitUsdTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/InitUsdTests.cs
@@ -55,10 +55,16 @@ public class InitUsdTests
     public void InitUsd_Initialize()
     {
         // Reset 'm_usdInitialized' for accurate testing
-        var isUsdInitialized = typeof(InitUsd).GetField("m_usdInitialized", (BindingFlags.Static | BindingFlags.NonPublic));
-        isUsdInitialized.SetValue(null, false);
+        ResetInitUsd();
 
         Assert.True(InitUsd.Initialize());
+    }
+
+    [TearDown]
+    public void ResetInitUsd()
+    {
+        var isUsdInitialized = typeof(InitUsd).GetField("m_usdInitialized", (BindingFlags.Static | BindingFlags.NonPublic));
+        isUsdInitialized.SetValue(null, false);
     }
 
     private MethodInfo GetMethod(string methodName)

--- a/package/com.unity.formats.usd/Tests/Editor/InitUsdTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/InitUsdTests.cs
@@ -65,7 +65,9 @@ public class InitUsdTests
         var method = typeof(InitUsd).GetMethod(methodName, (BindingFlags.NonPublic | BindingFlags.Static));
 
         if (method == null)
+        {
             Assert.Fail(string.Format("{0} method not found", methodName));
+        }
 
         return method;
     }

--- a/package/com.unity.formats.usd/Tests/Editor/InitUsdTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/InitUsdTests.cs
@@ -1,14 +1,7 @@
-using System.Collections;
 using System.IO;
 using NUnit.Framework;
-using UnityEditor;
-using UnityEngine;
-using UnityEngine.TestTools;
-using USD.NET;
-using USD.NET.Unity;
 using System.Reflection;
 using Unity.Formats.USD;
-using System.Runtime.CompilerServices;
 
 public class InitUsdTests
 {

--- a/package/com.unity.formats.usd/Tests/Editor/InitUsdTests.cs.meta
+++ b/package/com.unity.formats.usd/Tests/Editor/InitUsdTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 321361317709ca04bb9c63cea4906b0a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Purpose of this PR

[USDU-249](https://jira.unity3d.com/browse/USDU-249)


## Testing
Adds test cases for InitUsd script
tries to check if an early throw / exit is done when given wrong parameter value for function InitUsd.SetupUsdPath()

**Complexity:**
1

**Halo Effect:**
1
