### PR TITLE
[Draft] Fix for JointsMatch

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Skel/SkeletonImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Skel/SkeletonImporter.cs
@@ -159,6 +159,15 @@ namespace Unity.Formats.USD
                 return true;
             }
 
+            if (lhs.Length != rhs.Length)
+                return false;
+
+            for (int i = 0; i < lhs.Length; i++)
+            {
+                if (lhs[i] != rhs[i])
+                    return false;
+            }
+
             return true;
         }
 


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** PR #308 

A user pointed out that JointsMatch() functionality regressed in PR #261, resulting in it returning true in nearly all cases. 

I'm not sure whether the intended functionality for this method is to just check whether the two inputs are the same instance, or whether the full array of strings is the same, but as the behavior prior to the change was the latter I have reverted it to do that.

## Testing

**Functional Testing status:**

Not sure how best to test this as no repro case was supplied. I'll run the normal test suite.

**Performance Testing status:**

Very small performance impact expected due to the amount of string comparisons that may be introduced.

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:** minimal
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:** minimal
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
