### PR TITLE
[USDU-275] Adds testcase for checking if export keeps the original data structure

### DIFF
--- a/package/com.unity.formats.usd/Tests/Common/CustomAsserts/ExportAssert.cs
+++ b/package/com.unity.formats.usd/Tests/Common/CustomAsserts/ExportAssert.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+using NUnit.Framework;
+
+namespace Unity.Formats.USD.Tests
+{
+    public static class ExportAssert
+    {
+        public static class Runtime
+        {
+            public static void IsDataStructureKeptInUsdz(GameObject importedObject, string expectedObjectName, string expectedRootPrimName, string expectedMaterialsName)
+            {
+                Assert.AreEqual(importedObject.name, expectedObjectName);
+
+                var rootPrim = importedObject.transform.Find(expectedRootPrimName);
+                var materials = importedObject.transform.Find(expectedMaterialsName);
+
+                Assert.IsNotNull(rootPrim, string.Format("Root Prim was not found under expected name '{0}'", expectedRootPrimName));
+                Assert.IsNotNull(materials, string.Format("Materials was not found under expected name '{0}'", expectedMaterialsName));
+
+                Assert.IsNotNull(rootPrim.GetComponent<UsdPrimSource>(), "Root Prim GameObject did not contain UsdPrimSource component");
+                Assert.IsNotNull(materials.GetComponent<UsdPrimSource>(), "Materials GameObject did not contain UsdPrimSource component");
+
+                var materialsData = materials.transform.Find(expectedObjectName);
+                var rootPrimData = rootPrim.transform.Find(expectedObjectName);
+
+                Assert.IsNotNull(rootPrimData, string.Format("Root Prim Data was not found under expected name '{0}'", expectedObjectName));
+                Assert.IsNotNull(materialsData, string.Format("Materials Data was not found under expected name '{0}'", expectedObjectName));
+
+                Assert.IsNotNull(rootPrimData.GetComponent<UsdPrimSource>(), "Root Prim Data GameObject did not contain UsdPrimSource component");
+                Assert.IsNotNull(materialsData.GetComponent<UsdPrimSource>(), "Materials Data GameObject did not contain UsdPrimSource component");
+            }
+        }
+    }
+}

--- a/package/com.unity.formats.usd/Tests/Common/CustomAsserts/ExportAssert.cs
+++ b/package/com.unity.formats.usd/Tests/Common/CustomAsserts/ExportAssert.cs
@@ -5,30 +5,27 @@ namespace Unity.Formats.USD.Tests
 {
     public static class ExportAssert
     {
-        public static class Runtime
+        public static void IsDataStructureKeptInUsdz(GameObject importedObject, string expectedObjectName, string expectedRootPrimName, string expectedMaterialsName)
         {
-            public static void IsDataStructureKeptInUsdz(GameObject importedObject, string expectedObjectName, string expectedRootPrimName, string expectedMaterialsName)
-            {
-                Assert.AreEqual(importedObject.name, expectedObjectName);
+            Assert.AreEqual(importedObject.name, expectedObjectName);
 
-                var rootPrim = importedObject.transform.Find(expectedRootPrimName);
-                var materials = importedObject.transform.Find(expectedMaterialsName);
+            var rootPrim = importedObject.transform.Find(expectedRootPrimName);
+            var materials = importedObject.transform.Find(expectedMaterialsName);
 
-                Assert.IsNotNull(rootPrim, string.Format("Root Prim was not found under expected name '{0}'", expectedRootPrimName));
-                Assert.IsNotNull(materials, string.Format("Materials was not found under expected name '{0}'", expectedMaterialsName));
+            Assert.IsNotNull(rootPrim, string.Format("Root Prim was not found under expected name '{0}'", expectedRootPrimName));
+            Assert.IsNotNull(materials, string.Format("Materials was not found under expected name '{0}'", expectedMaterialsName));
 
-                Assert.IsNotNull(rootPrim.GetComponent<UsdPrimSource>(), "Root Prim GameObject did not contain UsdPrimSource component");
-                Assert.IsNotNull(materials.GetComponent<UsdPrimSource>(), "Materials GameObject did not contain UsdPrimSource component");
+            Assert.IsNotNull(rootPrim.GetComponent<UsdPrimSource>(), "Root Prim GameObject did not contain UsdPrimSource component");
+            Assert.IsNotNull(materials.GetComponent<UsdPrimSource>(), "Materials GameObject did not contain UsdPrimSource component");
 
-                var materialsData = materials.transform.Find(expectedObjectName);
-                var rootPrimData = rootPrim.transform.Find(expectedObjectName);
+            var materialsData = materials.transform.Find(expectedObjectName);
+            var rootPrimData = rootPrim.transform.Find(expectedObjectName);
 
-                Assert.IsNotNull(rootPrimData, string.Format("Root Prim Data was not found under expected name '{0}'", expectedObjectName));
-                Assert.IsNotNull(materialsData, string.Format("Materials Data was not found under expected name '{0}'", expectedObjectName));
+            Assert.IsNotNull(rootPrimData, string.Format("Root Prim Data was not found under expected name '{0}'", expectedObjectName));
+            Assert.IsNotNull(materialsData, string.Format("Materials Data was not found under expected name '{0}'", expectedObjectName));
 
-                Assert.IsNotNull(rootPrimData.GetComponent<UsdPrimSource>(), "Root Prim Data GameObject did not contain UsdPrimSource component");
-                Assert.IsNotNull(materialsData.GetComponent<UsdPrimSource>(), "Materials Data GameObject did not contain UsdPrimSource component");
-            }
+            Assert.IsNotNull(rootPrimData.GetComponent<UsdPrimSource>(), "Root Prim Data GameObject did not contain UsdPrimSource component");
+            Assert.IsNotNull(materialsData.GetComponent<UsdPrimSource>(), "Materials Data GameObject did not contain UsdPrimSource component");
         }
     }
 }

--- a/package/com.unity.formats.usd/Tests/Common/CustomAsserts/ExportAssert.cs.meta
+++ b/package/com.unity.formats.usd/Tests/Common/CustomAsserts/ExportAssert.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5a3ec5d050a6c64197a4333979de0bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/Editor/ExportTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/ExportTests.cs
@@ -117,5 +117,40 @@ namespace Unity.Formats.USD.Tests
             }
             Assert.AreEqual(cubes.Length, exportedPrims.Count, "One or more GameObjects don't have a corresponding Prim");
         }
+
+        [Test]
+        [Ignore("[USDU-275] | [USDU-279]")]
+        public void ExportAsUsdz_DataStructureKeptOnImport()
+        {
+            var scene = ImportHelpers.InitForOpen(GetTestAssetPath(TestAssetData.FileName.TexturedOpaque));
+            var importedUsdObject = ImportHelpers.ImportSceneAsGameObject(scene, importOptions:
+                new SceneImportOptions()
+                {
+                    materialImportMode = MaterialImportMode.ImportPreviewSurface
+                }
+            );
+
+            var usdzPath = GetUSDScenePath(importedUsdObject.name + ".usdz");
+            UsdzExporter.ExportUsdz(usdzPath, importedUsdObject);
+
+            var usdObjectRootPath = importedUsdObject.GetComponent<UsdAsset>().m_usdRootPath;
+
+            var usdzScene = ImportHelpers.InitForOpen(usdzPath);
+            var usdzObject = ImportHelpers.ImportSceneAsGameObject(usdzScene, importOptions:
+                new SceneImportOptions()
+                {
+                    materialImportMode = MaterialImportMode.ImportPreviewSurface
+                }
+            );
+
+            Assert.AreEqual(usdzObject.GetComponent<UsdAsset>().m_usdRootPath, usdObjectRootPath);
+
+            ExportAssert.IsDataStructureKeptInUsdz(
+                usdzObject,
+                expectedMaterialsName: TestAssetData.ImportGameObjectName.Material,
+                expectedRootPrimName: TestAssetData.ImportGameObjectName.RootPrim,
+                expectedObjectName: TestAssetData.FileName.TexturedOpaque
+            );
+        }
     }
 }

--- a/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs
@@ -113,7 +113,7 @@ namespace Unity.Formats.USD.Tests
 
         [Ignore("[USDU-275] | [USDU-279]")]
         [Test]
-        public void ExportAsUsdz_DataStructureKept()
+        public void ExportAsUsdz_DataStructureKeptOnImport()
         {
             var scene = ImportHelpers.InitForOpen(GetTestAssetPath(TestAssetData.FileName.TexturedOpaque));
             var importedUsdObject = ImportHelpers.ImportSceneAsGameObject(scene, importOptions:

--- a/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs
@@ -110,42 +110,5 @@ namespace Unity.Formats.USD.Tests
             ExportHelpers.ExportGameObjects(new[] { new GameObject("test") }, scene, BasisTransformation.SlowAndSafe);
             Assert.IsNull(scene.Stage);
         }
-
-        [Ignore("[USDU-275] | [USDU-279]")]
-        [Test]
-        public void ExportAsUsdz_DataStructureKeptOnImport()
-        {
-            var scene = ImportHelpers.InitForOpen(GetTestAssetPath(TestAssetData.FileName.TexturedOpaque));
-            var importedUsdObject = ImportHelpers.ImportSceneAsGameObject(scene, importOptions:
-                new SceneImportOptions()
-                {
-                    materialImportMode = MaterialImportMode.ImportPreviewSurface
-                }
-            );
-
-            var usdzPath = GetUSDScenePath(importedUsdObject.name + ".usdz");
-            UsdzExporter.ExportUsdz(usdzPath, importedUsdObject);
-
-            var usdObjectRootPath = importedUsdObject.GetComponent<UsdAsset>().m_usdRootPath;
-
-            Assert.AreEqual(usdObjectRootPath, "/");
-
-            var usdzScene = ImportHelpers.InitForOpen(usdzPath);
-            var usdzObject = ImportHelpers.ImportSceneAsGameObject(usdzScene, importOptions:
-                new SceneImportOptions()
-                {
-                    materialImportMode = MaterialImportMode.ImportPreviewSurface
-                }
-            );
-
-            Assert.AreEqual(usdzObject.GetComponent<UsdAsset>().m_usdRootPath, usdObjectRootPath);
-
-            ExportAssert.Runtime.IsDataStructureKeptInUsdz(
-                usdzObject,
-                expectedMaterialsName: TestAssetData.ImportGameObjectName.Material,
-                expectedRootPrimName: TestAssetData.ImportGameObjectName.RootPrim,
-                expectedObjectName: TestAssetData.FileName.TexturedOpaque
-            );
-        }
     }
 }

--- a/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs
+++ b/package/com.unity.formats.usd/Tests/Runtime/ExportHelpersTests.cs
@@ -110,5 +110,42 @@ namespace Unity.Formats.USD.Tests
             ExportHelpers.ExportGameObjects(new[] { new GameObject("test") }, scene, BasisTransformation.SlowAndSafe);
             Assert.IsNull(scene.Stage);
         }
+
+        [Ignore("[USDU-275] | [USDU-279]")]
+        [Test]
+        public void ExportAsUsdz_DataStructureKept()
+        {
+            var scene = ImportHelpers.InitForOpen(GetTestAssetPath(TestAssetData.FileName.TexturedOpaque));
+            var importedUsdObject = ImportHelpers.ImportSceneAsGameObject(scene, importOptions:
+                new SceneImportOptions()
+                {
+                    materialImportMode = MaterialImportMode.ImportPreviewSurface
+                }
+            );
+
+            var usdzPath = GetUSDScenePath(importedUsdObject.name + ".usdz");
+            UsdzExporter.ExportUsdz(usdzPath, importedUsdObject);
+
+            var usdObjectRootPath = importedUsdObject.GetComponent<UsdAsset>().m_usdRootPath;
+
+            Assert.AreEqual(usdObjectRootPath, "/");
+
+            var usdzScene = ImportHelpers.InitForOpen(usdzPath);
+            var usdzObject = ImportHelpers.ImportSceneAsGameObject(usdzScene, importOptions:
+                new SceneImportOptions()
+                {
+                    materialImportMode = MaterialImportMode.ImportPreviewSurface
+                }
+            );
+
+            Assert.AreEqual(usdzObject.GetComponent<UsdAsset>().m_usdRootPath, usdObjectRootPath);
+
+            ExportAssert.Runtime.IsDataStructureKeptInUsdz(
+                usdzObject,
+                expectedMaterialsName: TestAssetData.ImportGameObjectName.Material,
+                expectedRootPrimName: TestAssetData.ImportGameObjectName.RootPrim,
+                expectedObjectName: TestAssetData.FileName.TexturedOpaque
+            );
+        }
     }
 }


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:**
[[USDU-275](https://jira.unity3d.com/browse/USDU-275)] & [[USDU-279](https://jira.unity3d.com/browse/USDU-279)]

## Testing
ExportAsUsdz_DataStructureKeptOnImport:
1. Imports a known USDA file
2. Exports it as a UDSZ file
3. Import the USDZ file
4. Check if the imported USDZ file maintains the same game object structure as the initially imported USDA file

**Complexity:**
1

**Halo Effect:**
1

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
