### PR TITLE
Optimized PointInstance importing

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/InstanceImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/InstanceImporter.cs
@@ -86,11 +86,11 @@ namespace Unity.Formats.USD
                 }
             }
 
-            var inactiveIds = new System.Collections.Generic.HashSet<long>();
             /*
              * Disabled until this bug is resolved:
              * https://github.com/PixarAnimationStudios/USD/issues/639
              *
+            var inactiveIds = new System.Collections.Generic.HashSet<long>();
             if (sample.inactiveIds != null) {
               foreach (long id in sample.inactiveIds.GetExplicitItems()) {
                 inactiveIds.Add(id);
@@ -104,10 +104,12 @@ namespace Unity.Formats.USD
             int instanceCount = 0;
             foreach (var index in sample.protoIndices)
             {
+                /*
                 if (inactiveIds.Contains(index))
                 {
                     continue;
                 }
+                */
 
                 if (index >= sample.prototypes.targetPaths.Length)
                 {

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/InstanceImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/InstanceImporter.cs
@@ -153,7 +153,7 @@ namespace Unity.Formats.USD
                 goInstance.SetActive(true);
                 goInstance.name = instancesToCreate[instanceNum].Item2;
                 XformImporter.BuildXform(instancesToCreate[instanceNum].Item1, goInstance, options);
-                
+
                 primMap.AddInstance(goInstance);
             }
         }

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/InstanceImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/InstanceImporter.cs
@@ -75,7 +75,7 @@ namespace Unity.Formats.USD
                 GameObject go;
                 if (!primMap.TryGetValue(new pxr.SdfPath(protoRoot), out go))
                 {
-                    Debug.LogWarning("Proto not found in PrimMap: " + protoRoot);
+                    Debug.LogWarning($"Proto not found in PrimMap: {protoRoot}. Instances of this prototype cannot be instantiated.");
                     continue;
                 }
 
@@ -123,7 +123,6 @@ namespace Unity.Formats.USD
                 GameObject goMaster;
                 if (!primMap.TryGetValue(new pxr.SdfPath(targetPath), out goMaster))
                 {
-                    Debug.LogWarning("Proto not found in PrimMap: " + targetPath);
                     continue;
                 }
 


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** N/A

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->

PR #331 introduced lots of Transform.Find calls when importing a PointInstancer, which in initial testing didn't appear to introduce a regression but has since proved to be problematic. Discussing with @John-Whigham, we discovered this is because the order of the transform hierarchy means one behaviour is best case (finding each child immediately, deleting it, then recreating on the end) while the other is worst case (not finding the child so searching to the end, with each iteration larger than the last). In profiling this divided loop proves to be much faster, when we destroy all the old objects first before re-instantiating, in all cases.

## Testing

**Functional Testing status:**

Tested on Pixar's PointInstancedMedCity file.

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

Before: 
![image](https://user-images.githubusercontent.com/45685026/216310575-3b5f4d29-c08b-42ea-9185-fa49a965d23e.png)


After:
![image](https://user-images.githubusercontent.com/45685026/216310766-3a3b3461-7676-4062-a37a-454d0fa9cd31.png)

Tested that initial import, re-import and refresh from USD no longer take a ridiculous time (>1minute) both in a cold and warm editor.


## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:** low
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:** low
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
