### PR TITLE
Change our mac vm to mac 12 as the graphics requirement in our tests are failing on vms without metal graphics api

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -10,8 +10,8 @@ test_platforms:
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/macos-12:stable
-    flavor: m1.mac
+    image: slough-ops/macos-11-base:stable
+    flavor: b1.large
 test_backends:
   - name: il2cpp
     editor: 2020.3

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -10,7 +10,8 @@ test_platforms:
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/mac:stable
+    model: M1
+    image: package-ci/macos-12-arm-base
     flavor: m1.mac
 test_backends:
   - name: il2cpp

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -10,8 +10,7 @@ test_platforms:
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx
-    model: M1
-    image: package-ci/macos-12-arm-base
+    image: package-ci/macos-11-base
     flavor: m1.mac
 test_backends:
   - name: il2cpp

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -10,7 +10,7 @@ test_platforms:
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/macos-11-base
+    image: package-ci/macos-12:stable
     flavor: m1.mac
 test_backends:
   - name: il2cpp

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -10,7 +10,7 @@ test_platforms:
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/macos-12:v4
+    image: package-ci/macos-11:default
     flavor: m1.mac
 test_backends:
   - name: il2cpp

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -10,8 +10,8 @@ test_platforms:
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx
-    image: slough-ops/macos-11-base:stable
-    flavor: b1.large
+    image: package-ci/macos-12:v4
+    flavor: m1.mac
 test_backends:
   - name: il2cpp
     editor: 2020.3

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -10,7 +10,7 @@ test_platforms:
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/macos-11:default
+    image: package-ci/macos-12:default
     flavor: m1.mac
 test_backends:
   - name: il2cpp


### PR DESCRIPTION

## Purpose of this PR

**Ticket/Jira #:**
https://jira.unity3d.com/browse/USDU-318

## Testing

**Functional Testing status:**
N/A
**Performance Testing status:**
N/A

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
1

**Halo Effect:**
1

## Additional information
Slack thread:
https://unity.slack.com/archives/C0JHA6J4C/p1677792279052949

This change is required for our tests to run on the Trunk version of Unity, older versions of Unity did not require this change
Therefore it does unnecessarily change the minimum requirements for our tests on older versions of Unity

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
