### PR TITLE
Remove unused variable in TypeBinder.

### DIFF
--- a/package/com.unity.formats.usd/Dependencies/USD.NET/serialization/TypeBinder.cs
+++ b/package/com.unity.formats.usd/Dependencies/USD.NET/serialization/TypeBinder.cs
@@ -113,11 +113,9 @@ namespace USD.NET
             // Check if the given sdf type name is an alias
             // https://graphics.pixar.com/usd/docs/api/_usd__page__datatypes.html#Usd_Roles
             string name;
-            bool match = true;
             if (!typeAliases.TryGetValue(key.GetAsToken(), out name))
             {
                 name = key.GetAsToken();
-                match = false;
             }
 
             // TODO: we could keep a reverse mapping, but waiting for deeper performance analysis first.


### PR DESCRIPTION
Removes the cause of warning: 
```package\com.unity.formats.usd\Dependencies\USD.NET\serialization\TypeBinder.cs(116,18): warning CS0219: The variable 'match' is assigned but its value is never used```

I'm not sure if this was originally added with the intention of allowing for some early out, but currently it's not doing anything and is flagging a warning on installing the package, so removing.

## Purpose of this PR

**Ticket/Jira #:**

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->


## Testing

**Functional Testing status:** Confirmed locally warning no longer appears in 2019.4, CI running.

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

**Performance Testing status:** N/A

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
<!-- (Minimal / Low / Medium / High) --> 0

**Halo Effect:**
<!-- (Minimal / Low / Medium / High) --> 0

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
