### PR TITLE
[USDU-328] Fix for IndexOutOfRangeException when importing UsdSkel

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
@@ -361,13 +361,17 @@ namespace Unity.Formats.USD
 
             int isNotConstant = weightsInterpolation.GetString() == UsdGeomTokens.constant ? 0 : 1;
 
+            // Convert the USD joint weights and indices into a Unity BoneWeights array, including remapping to the new triangulated vertices where required
             for (var vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++)
             {
+                // For every new vertex, get the original vertex if it has been triangulated
                 var originalVertexIndex = remapIndices ? usdMesh.triangulatedFaceVertexIndices[vertexIndex] * weightsElementSize : vertexIndex * weightsElementSize;
                 var vertexLookupIndex = isNotConstant * originalVertexIndex;
 
+                // This intermediary array is faster than getting/setting to a NativeArray in a loop
                 bonesPerVertexArray[vertexIndex] = (byte)weightsElementSize;
 
+                // Create a BoneWeight for every element at every vertex
                 for (var weightElementIndex = 0; weightElementIndex < weightsElementSize; weightElementIndex++)
                 {
                     var boneWeight = new BoneWeight1();

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
@@ -346,8 +346,9 @@ namespace Unity.Formats.USD
                 throw new Exception("Joints weights information are invalid or empty for: " + path);
             }
 
-            var bonesPerVertex = new NativeArray<byte>(unityMesh.vertexCount, Allocator.Temp);
-            var boneWeights1 = new NativeArray<BoneWeight1>(unityMesh.vertexCount * weightsElementSize, Allocator.Temp);
+            int vertexCount = unityMesh.vertexCount;
+            var bonesPerVertexArray = new byte[vertexCount];
+            var boneWeightsArray = new BoneWeight1[vertexCount * weightsElementSize];
 
             // Remap the vertex indices if mesh attribute have been converted to faceVarying
             var remapIndices = weightsInterpolation.GetString() == UsdGeomTokens.vertex
@@ -355,22 +356,24 @@ namespace Unity.Formats.USD
 
             int isNotConstant = weightsInterpolation.GetString() == UsdGeomTokens.constant ? 0 : 1;
 
-            for (var i = 0; i < unityMesh.vertexCount; i++)
+            for (var vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++)
             {
-                var unityIndex = remapIndices ? usdMesh.triangulatedFaceVertexIndices[i] * weightsElementSize : i * weightsElementSize;
-                var usdIndex = isNotConstant * unityIndex;
+                var originalVertexIndex = remapIndices ? usdMesh.triangulatedFaceVertexIndices[vertexIndex] * weightsElementSize : vertexIndex * weightsElementSize;
+                var vertexLookupIndex = isNotConstant * originalVertexIndex;
 
-                bonesPerVertex[i] = (byte)weightsElementSize;
+                bonesPerVertexArray[vertexIndex] = (byte)weightsElementSize;
 
-                for (var wi = 0; wi < weightsElementSize; wi++)
+                for (var weightElementIndex = 0; weightElementIndex < weightsElementSize; weightElementIndex++)
                 {
-                    var bw = boneWeights1[i * weightsElementSize + wi];
-                    bw.boneIndex = indices[usdIndex + wi];
-                    bw.weight = weights[usdIndex + wi];
-                    boneWeights1[i * weightsElementSize + wi] = bw;
+                    var boneWeight = new BoneWeight1();
+                    boneWeight.boneIndex = indices[vertexLookupIndex + weightElementIndex];
+                    boneWeight.weight = weights[vertexLookupIndex + weightElementIndex];
+                    boneWeightsArray[vertexIndex * weightsElementSize + weightElementIndex] = boneWeight;
                 }
             }
             // TODO: Investigate if bone weights should be normalized before this line.
+            var bonesPerVertex = new NativeArray<byte>(bonesPerVertexArray, Allocator.Temp);
+            var boneWeights1 = new NativeArray<BoneWeight1>(boneWeightsArray, Allocator.Temp);
             unityMesh.SetBoneWeights(bonesPerVertex, boneWeights1);
             bonesPerVertex.Dispose();
             boneWeights1.Dispose();

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Geometry/MeshImporter.cs
@@ -346,6 +346,11 @@ namespace Unity.Formats.USD
                 throw new Exception("Joints weights information are invalid or empty for: " + path);
             }
 
+            if (weightsElementSize != indicesElementSize)
+            {
+                throw new Exception("Mismatch in joints weight and indices element sizes for: " + path);
+            }
+
             int vertexCount = unityMesh.vertexCount;
             var bonesPerVertexArray = new byte[vertexCount];
             var boneWeightsArray = new BoneWeight1[vertexCount * weightsElementSize];

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/SanitizedSamples.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/SanitizedSamples.cs
@@ -170,8 +170,10 @@ namespace Unity.Formats.USD
 
         public void BackupTopology()
         {
-            originalFaceVertexCounts = (int[])faceVertexCounts.Clone();
-            originalFaceVertexIndices = (int[])faceVertexIndices.Clone();
+            originalFaceVertexCounts = new int[faceVertexCounts.Length];
+            Buffer.BlockCopy(faceVertexCounts, 0, originalFaceVertexCounts, 0, Buffer.ByteLength(faceVertexCounts));
+            originalFaceVertexIndices = new int[faceVertexIndices.Length];
+            Buffer.BlockCopy(faceVertexIndices, 0, originalFaceVertexIndices, 0, Buffer.ByteLength(faceVertexIndices));
         }
 
         public bool IsTopologyBackedUp()
@@ -372,15 +374,14 @@ namespace Unity.Formats.USD
                     last += faceVertexCounts[i];
                 }
             }
+            
+            faceVertexIndices = newIndices;
 
-            faceVertexIndices = new int[newIndicesLength];
-            Array.Copy(newIndices, faceVertexIndices, newIndicesLength);
-
+            // triangulatedFaceVertexIndices needs to be a 'proper' copy of newIndices, else it will be affected when faceVertexIndices is modified
             triangulatedFaceVertexIndices = new int[newIndicesLength];
-            Array.Copy(newIndices, triangulatedFaceVertexIndices, newIndicesLength);
+            Buffer.BlockCopy(newIndices, 0, triangulatedFaceVertexIndices, 0, Buffer.ByteLength(newIndices));
 
-            faceVertexCounts = new int[newFaceCountsLength];
-            Array.Copy(newCounts, faceVertexCounts, newFaceCountsLength);// TODO: As this is always 3, remove it and only create on export to USD
+            faceVertexCounts = newCounts;
         }
 
         internal bool ShouldUnweldVertices(bool bindMaterials)

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/SanitizedSamples.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/SanitizedSamples.cs
@@ -492,33 +492,47 @@ namespace Unity.Formats.USD
             }
         }
 
-        internal static void TriangulateAttributes<T>(ref T[] values, int[] faceVertexCount, bool changeHandedness)
+        internal static void TriangulateAttributes<T>(ref T[] values, int[] faceVertexCounts, bool changeHandedness)
         {
-            var newValues = new List<T>();
-            var last = 0;
-            for (var faceIndex = 0; faceIndex < faceVertexCount.Length; faceIndex++)
+            int newFacesCount = 0;
+            for (int i = 0; i < faceVertexCounts.Length; i++)
             {
-                var next = last + 1;
-                for (var triangleIndex = 0; triangleIndex < faceVertexCount[faceIndex] - 2; triangleIndex++)
-                {
-                    if (changeHandedness)
-                    {
-                        newValues.Add(values[next++]);
-                        newValues.Add(values[last]);
-                        newValues.Add(values[next]);
-                    }
-                    else
-                    {
-                        newValues.Add(values[last]);
-                        newValues.Add(values[next++]);
-                        newValues.Add(values[next]);
-                    }
-                }
-
-                last += faceVertexCount[faceIndex];
+                newFacesCount += faceVertexCounts[i] - 2;
             }
 
-            values = newValues.ToArray();
+            var newValues = new T[3 * newFacesCount]; // we're converting every face to a triangle, so must be three verts per face
+
+            int last = 0, currentIndex = 0;
+            if (changeHandedness)
+            {
+                for (var faceIndex = 0; faceIndex < faceVertexCounts.Length; faceIndex++)
+                {
+                    var next = last + 1;
+                    for (var triangleIndex = 0; triangleIndex < faceVertexCounts[faceIndex] - 2; triangleIndex++)
+                    {
+                        newValues[currentIndex++] = values[next++];
+                        newValues[currentIndex++] = values[last];
+                        newValues[currentIndex++] = values[next];
+                    }
+                    last += faceVertexCounts[faceIndex];
+                }
+            }
+            else
+            {
+                for (var faceIndex = 0; faceIndex < faceVertexCounts.Length; faceIndex++)
+                {
+                    var next = last + 1;
+                    for (var triangleIndex = 0; triangleIndex < faceVertexCounts[faceIndex] - 2; triangleIndex++)
+                    {
+                        newValues[currentIndex++] = values[last];
+                        newValues[currentIndex++] = values[next++];
+                        newValues[currentIndex++] = values[next];
+                    }
+                    last += faceVertexCounts[faceIndex];
+                }
+            }
+
+            values = newValues;
         }
 
         /// <summary>

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/SanitizedSamples.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/SanitizedSamples.cs
@@ -317,9 +317,9 @@ namespace Unity.Formats.USD
             // count the length of newCounts to pre-allocate the array-
             // this extra loop is more performant than using a dynamically-sized List
             int newFaceCountsLength = 0;
-            for (int i = 0; i < faceVertexCounts.Length; i++)
+            foreach (int faceVertexCount in faceVertexCounts)
             {
-                newFaceCountsLength += faceVertexCounts[i] - 2;
+                newFaceCountsLength += faceVertexCount - 2;
             }
 
             // We only have tris, so 3 indices per face
@@ -495,9 +495,9 @@ namespace Unity.Formats.USD
         internal static void TriangulateAttributes<T>(ref T[] values, int[] faceVertexCounts, bool changeHandedness)
         {
             int newFacesCount = 0;
-            for (int i = 0; i < faceVertexCounts.Length; i++)
+            foreach (int faceVertexCount in faceVertexCounts)
             {
-                newFacesCount += faceVertexCounts[i] - 2;
+                newFacesCount += faceVertexCount - 2;
             }
 
             var newValues = new T[3 * newFacesCount]; // we're converting every face to a triangle, so must be three verts per face
@@ -548,7 +548,7 @@ namespace Unity.Formats.USD
 
             if (interpolation != null && interpolation != newInterpolation)
             {
-                UnityEngine.Debug.LogWarning($"Stated interpolation '{interpolation.ToString()}' for this PrimVar does not match required value counts. " +
+                UnityEngine.Debug.LogWarning($"Stated interpolation '{interpolation.ToString()}' for a PrimVar does not match required value counts. " +
                     $"We will convert to FaceVarying assuming an original interpolation of '{newInterpolation.ToString()}'.");
             }
 

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/SanitizedSamples.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/SanitizedSamples.cs
@@ -374,7 +374,7 @@ namespace Unity.Formats.USD
                     last += faceVertexCounts[i];
                 }
             }
-            
+
             faceVertexIndices = newIndices;
 
             // triangulatedFaceVertexIndices needs to be a 'proper' copy of newIndices, else it will be affected when faceVertexIndices is modified

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/SanitizedSamples.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/SanitizedSamples.cs
@@ -373,9 +373,14 @@ namespace Unity.Formats.USD
                 }
             }
 
-            faceVertexIndices = newIndices;
-            triangulatedFaceVertexIndices = newIndices;
-            faceVertexCounts = newCounts;  // TODO: As this is always 3, remove it and only create on export to USD
+            faceVertexIndices = new int[newIndicesLength];
+            Array.Copy(newIndices, faceVertexIndices, newIndicesLength);
+
+            triangulatedFaceVertexIndices = new int[newIndicesLength];
+            Array.Copy(newIndices, triangulatedFaceVertexIndices, newIndicesLength);
+
+            faceVertexCounts = new int[newFaceCountsLength];
+            Array.Copy(newCounts, faceVertexCounts, newFaceCountsLength);// TODO: As this is always 3, remove it and only create on export to USD
         }
 
         internal bool ShouldUnweldVertices(bool bindMaterials)


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** USDU-328 / #352 
Fixes the IndexOutOfRangeException when importing Pixar's Human Female UsdSkel example. My PR #343 introduced a regression for Skinned Meshes, which use the cached triangulatedFaceVertexIndices to map from the new unwelded vertices to the old ones. My change to switch from a List to an array hid that there was no longer a copy, so the triangulatedFaceVertexIndices was now referencing the same array as faceVertexIndices, which was later changed. I've changed all the arrays that are needed to hold backups in this code to have a copy.

There was also an unreported issue with ALab 2 where some of the arbitrary primvars are stated to have face varying interpolation, but do not have one value per vertex per face, which is a (potentially problematic) requirement in our import process. I changed this to give a warning and use GuessInterpolation to find the next best behaviour. 

This PR also optimizes ImportSkinning a bit, by removing costly gets and sets to native arrays, and instead working on a managed array that is fed into a native array later.

## Testing

**Functional Testing status:**
Manually tested on Pixar's human female, ALab and another triangle-heavy file. I'd like to add some automated tests but this isn't straightforward for this edge case (we have existing tests in this area that didn't catch it).

**Performance Testing status:**
The copying of the array does unfortunately regress the performance. I minimized as much as possible by using the lightweight Buffer.BlockCopy, but in the 'SphereCube' sample this increases the Triangulate time by ~40%. However, coupled with the optimization for TriangulateAttributes(), overall the import for ALab improved from 45s to 39s on my machine, so the extra <1s in BackupTopology() is somewhat less noticeable.

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:** Low
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:** Low
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
