### PR TITLE
[USDU-329] Change the wait criteria of flaky test cases

### DIFF
--- a/package/com.unity.formats.usd/Tests/Editor/USDPayloadComponentTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/USDPayloadComponentTests.cs
@@ -207,6 +207,7 @@ namespace Unity.Formats.USD.Tests
             Assume.That(usdPayload.IsLoaded, Is.False, "UsdPayload.IsLoaded should be set to false.");
         }
 
+        [Ignore("[USDU-329] Unstable test result")]
         [UnityTest]
         public IEnumerator ChangingUsdPayloadStateFromUnloadedToLoaded_MarksSceneDirty()
         {
@@ -224,6 +225,7 @@ namespace Unity.Formats.USD.Tests
             Assert.IsTrue(m_UnityScene.isDirty, "Scene should be dirty after changing UsdPayload objects");
         }
 
+        [Ignore("[USDU-329] Unstable test result")]
         [UnityTest]
         public IEnumerator ChangingUsdPayloadStateFromLoadedToUnloaded_MarksSceneDirty()
         {

--- a/package/com.unity.formats.usd/Tests/Editor/USDPayloadComponentTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/USDPayloadComponentTests.cs
@@ -210,44 +210,53 @@ namespace Unity.Formats.USD.Tests
         [UnityTest]
         public IEnumerator ChangingUsdPayloadStateFromUnloadedToLoaded_MarksSceneDirty()
         {
-            const int timeOutSeconds = 3;
+            const int timeOutFrames = 3;
 
             m_usdAsset.m_payloadPolicy = PayloadPolicy.DontLoadPayloads;
             m_usdAsset.Reload(forceRebuild: true);
+            // Wait at least one frame for Reload
             yield return null;
 
             EditorSceneManager.SaveScene(m_UnityScene, GetUnityScenePath());
-            Assert.IsFalse(m_UnityScene.isDirty, "Scene should not be dirty after after saving");
+            Assert.IsFalse(m_UnityScene.isDirty, "Scene should not be dirty after saving");
 
-            float loadingTime = 0;
             m_usdRoot.GetComponentInChildren<UsdPayload>().Load();
-
-            while (!m_UnityScene.isDirty && loadingTime < timeOutSeconds)
+            var startingFrame = Time.frameCount;
+            // Wait at least one frame to ensure Update runs, break out if we hit either the condition or have waited for too many frames
+            while (!m_UnityScene.isDirty && Time.frameCount - startingFrame < timeOutFrames)
             {
-                loadingTime += Time.deltaTime;
                 yield return null;
             }
 
-            Assert.Less(loadingTime, timeOutSeconds);
-            Assert.True(m_UnityScene.isDirty);
+            Assert.Less(Time.frameCount - startingFrame, timeOutFrames, $"Timeout: Payload Unload should be done within {timeOutFrames} frames");
+            Assert.True(m_UnityScene.isDirty, "Scene should be dirty after Payload Load");
         }
 
         [UnityTest]
         public IEnumerator ChangingUsdPayloadStateFromUnloadedToLoaded_GeneratesPayloadObjects()
         {
+            const int timeOutFrames = 3;
+
             m_usdAsset.m_payloadPolicy = PayloadPolicy.DontLoadPayloads;
             m_usdAsset.Reload(forceRebuild: true);
+            // Wait at least one frame for Reload
             yield return null;
 
             EditorSceneManager.SaveScene(m_UnityScene, GetUnityScenePath());
-            Assert.IsFalse(m_UnityScene.isDirty, "Scene should not be dirty after after saving");
+            Assert.IsFalse(m_UnityScene.isDirty, "Scene should not be dirty after saving");
 
             var payloadRoot = m_usdRoot.GetComponentInChildren<UsdPayload>();
             var payloadRootChildCount = payloadRoot.transform.childCount;
 
             payloadRoot.Load();
-            yield return new WaitUntil(() => m_UnityScene.isDirty == true);
+            var startingFrame = Time.frameCount;
+            // Wait at least one frame to ensure Update runs, break out if we hit either the condition or have waited for too many frames
+            while (!m_UnityScene.isDirty && Time.frameCount - startingFrame < timeOutFrames)
+            {
+                yield return null;
+            }
 
+            Assert.Less(Time.frameCount - startingFrame, timeOutFrames, $"Timeout: Payload Unload should be done within {timeOutFrames} frames");
             Assert.IsTrue(payloadRoot == null, "Payload Load should reset USD related components and older references to it should be null");
 
             var newPayloadRoot = m_usdRoot.GetComponentInChildren<UsdPayload>();
@@ -257,44 +266,53 @@ namespace Unity.Formats.USD.Tests
         [UnityTest]
         public IEnumerator ChangingUsdPayloadStateFromLoadedToUnloaded_MarksSceneDirty()
         {
-            const int timeOutSeconds = 3;
+            const int timeOutFrames = 3;
 
             m_usdAsset.m_payloadPolicy = PayloadPolicy.LoadAll;
             m_usdAsset.Reload(forceRebuild: true);
+            // Wait at least one frame for Reload
             yield return null;
 
             EditorSceneManager.SaveScene(m_UnityScene, GetUnityScenePath());
-            Assert.IsFalse(m_UnityScene.isDirty, "Scene should not be dirty after after saving");
-
-            float loadingTime = 0;
+            Assert.IsFalse(m_UnityScene.isDirty, "Scene should not be dirty after saving");
 
             m_usdRoot.GetComponentInChildren<UsdPayload>().Unload();
-            while (!m_UnityScene.isDirty && loadingTime < timeOutSeconds)
+            var startingFrame = Time.frameCount;
+            // Wait at least one frame to ensure Update runs, break out if we hit either the condition or have waited for too many frames
+            while (!m_UnityScene.isDirty && Time.frameCount - startingFrame < timeOutFrames)
             {
-                loadingTime += Time.deltaTime;
                 yield return null;
             }
 
-            Assert.Less(loadingTime, timeOutSeconds);
-            Assert.True(m_UnityScene.isDirty);
+            Assert.Less(Time.frameCount - startingFrame, timeOutFrames, $"Timeout: Payload Unload should be done within {timeOutFrames} frames");
+            Assert.True(m_UnityScene.isDirty, "Scene should be dirty after Payload Unload");
         }
 
         [UnityTest]
         public IEnumerator ChangingUsdPayloadStateFromLoadedToUnloaded_DestroysPayloadObjects()
         {
+            const int timeOutFrames = 3;
+
             m_usdAsset.m_payloadPolicy = PayloadPolicy.LoadAll;
             m_usdAsset.Reload(forceRebuild: true);
+            // Wait at least one frame for Reload
             yield return null;
 
             EditorSceneManager.SaveScene(m_UnityScene, GetUnityScenePath());
-            Assert.IsFalse(m_UnityScene.isDirty, "Scene should not be dirty after after saving");
+            Assert.IsFalse(m_UnityScene.isDirty, "Scene should not be dirty after saving");
 
             var payloadRoot = m_usdRoot.GetComponentInChildren<UsdPayload>();
             var payloadRootChildCount = payloadRoot.transform.childCount;
 
             payloadRoot.Unload();
-            yield return new WaitUntil(() => m_UnityScene.isDirty == true);
+            var startingFrame = Time.frameCount;
+            // Wait at least one frame to ensure Update runs, break out if we hit either the condition or have waited for too many frames
+            while (!m_UnityScene.isDirty && Time.frameCount - startingFrame < timeOutFrames)
+            {
+                yield return null;
+            }
 
+            Assert.Less(Time.frameCount - startingFrame, timeOutFrames, $"Timeout: Payload Unload should be done within {timeOutFrames} frames");
             Assert.AreNotEqual(payloadRoot.transform.childCount, payloadRootChildCount, "Payload Unload should destroy the payload objects");
         }
     }


### PR DESCRIPTION
## Purpose of this PR

This PR attempts to circumvent the current error we are having with Unity ver. 2020.3 where 2 of our test cases, 
- ChangingUsdPayloadStateFromUnloadedToLoaded_MarksSceneDirty
- ChangingUsdPayloadStateFromLoadedToUnloaded_MarksSceneDirty

are often failing due to not waiting until the Payload Load / Unload has not fully updated the root payload GameObject

**Ticket/Jira #:**
[USDU-329](https://jira.unity3d.com/browse/USDU-329)

## Testing
**Functional Testing status:**
Changes the testcases:
- ChangingUsdPayloadStateFromUnloadedToLoaded_MarksSceneDirty
- ChangingUsdPayloadStateFromLoadedToUnloaded_MarksSceneDirty

Instead of doing an Assert on scene.isDirty, we wait until the scene has been dirtied, and then do an assert on the rootPayload Object's child count

This should solve the problem of not waiting long enough as well as scoping more into which GameObject within the scene has been changed

**Performance Testing status:**
N/A

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
<!-- (Minimal / Low / Medium / High) -->
1

**Halo Effect:**
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

I at first did not want to change the test cases to this extent, and wanted to gain more information on why only on UPM we are getting this problem with waiting for proper update
[Slack Thread 1](https://unity.slack.com/archives/C0JHA6J4C/p1680116747100079) & [Slack Thread 2](https://unity.slack.com/archives/C02A3U0UP9S/p1680115238408449)

Though I do believe the changes here are good for these 2 test cases, i would like to learn more about this UPM and Wait issue on Unity 2020.3 so that this doesnt happen again in the future - will update as soon as i get more info on this

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
