### PR TITLE
[USDU-342] Fix for importing materials exported with a newer version of USD.

### DIFF
--- a/package/com.unity.formats.usd/CHANGELOG.md
+++ b/package/com.unity.formats.usd/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 ### Bug Fixes
+- Fixed a bug where importing materials exported from a newer USD version would fail.
+
 - Fixed an import bug causing instanced primitives not to be sanitized.
 - Disabled plugins on unsupported platforms.
 - Fixed a bug causing PointInstances to be duplicated.

--- a/package/com.unity.formats.usd/CHANGELOG.md
+++ b/package/com.unity.formats.usd/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 ### Bug Fixes
-- Fixed a bug where importing materials exported from a newer USD version would fail.
+- Fixed a bug where importing materials exported from USD version >= 21.11 would fail.
 
 - Fixed an import bug causing instanced primitives not to be sanitized.
 - Disabled plugins on unsupported platforms.

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/MaterialImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/MaterialImporter.cs
@@ -242,6 +242,11 @@ namespace Unity.Formats.USD
                                 uvPrimvar = pxr.UsdCs.VtValueToTfToken(value).ToString();
                             else
                                 uvPrimvar = value;
+
+                            if (string.IsNullOrEmpty(uvPrimvar))
+                            {
+                                Debug.LogWarning($"uvPrimvar at <{connPath}> was unable to be read from USD file.");
+                            }
                         }
                         else
                         {

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/MaterialImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/MaterialImporter.cs
@@ -235,18 +235,16 @@ namespace Unity.Formats.USD
                         var attr = scene.GetAttributeAtPath(connPath);
                         if (attr != null)
                         {
-                            var value = attr.Get(scene.Time);
+                            pxr.VtValue value = attr.Get(scene.Time);
 
                             // This value type can be a string or a token, depending on USD version
-                            if (string.IsNullOrEmpty(value))
+                            string typeName = value.GetTypeName();
+                            if (typeName == "string")
+                                uvPrimvar = value;
+                            else if (typeName == "TfToken")
                                 uvPrimvar = pxr.UsdCs.VtValueToTfToken(value).ToString();
                             else
-                                uvPrimvar = value;
-
-                            if (string.IsNullOrEmpty(uvPrimvar))
-                            {
-                                Debug.LogWarning($"uvPrimvar at <{connPath}> was unable to be read from USD file.");
-                            }
+                                Debug.LogWarning($"Unexpected type <{typeName}> on uvPrimvar at <{connPath}>.");
                         }
                         else
                         {

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/MaterialImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/MaterialImporter.cs
@@ -237,7 +237,7 @@ namespace Unity.Formats.USD
                         {
                             pxr.VtValue value = attr.Get(scene.Time);
 
-                            // This value type can be a string or a token, depending on USD version
+                            // This value type is a TfToken in USD versions < 21.11, and a string in 21.11+
                             string typeName = value.GetTypeName();
                             if (typeName == "string")
                                 uvPrimvar = value;

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/MaterialImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/MaterialImporter.cs
@@ -236,7 +236,12 @@ namespace Unity.Formats.USD
                         if (attr != null)
                         {
                             var value = attr.Get(scene.Time);
-                            uvPrimvar = pxr.UsdCs.VtValueToTfToken(value).ToString();
+
+                            // This value type can be a string or a token, depending on USD version
+                            if (string.IsNullOrEmpty(value))
+                                uvPrimvar = pxr.UsdCs.VtValueToTfToken(value).ToString();
+                            else
+                                uvPrimvar = value;
                         }
                         else
                         {


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** USDU-342 / #353 

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->
In USD 21.11, the type of the UsdPrimvarReader.varname was changed from token to string. This change now handles both the token and string case in the material importer.
We should work on adding some test cases of USD files exported from newer USD versions to our suite of test files.

## Testing

**Functional Testing status:**

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

Tested files exported in both the older and newer versions to check both were as expected. 

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

Unlikely, simple change.

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:** 1
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:** 1
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [x] Add entry in CHANGELOG.md _(if applicable)_
