### PR TITLE
Allow importing USDZ in the open file menu

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/ImportHelpers.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/ImportHelpers.cs
@@ -158,7 +158,7 @@ namespace Unity.Formats.USD
         {
 #if UNITY_EDITOR
             if (String.IsNullOrEmpty(path) && !UnityEngine.Application.isPlaying)
-                path = EditorUtility.OpenFilePanel("Import USD File", "", "usd,usda,usdc,abc");
+                path = EditorUtility.OpenFilePanel("Import USD File", "", "usd,usda,usdc,usdz,abc");
 #endif
 
             if (String.IsNullOrEmpty(path))


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:**

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->

On Windows you previously had to change the file ending to see USDZ files, and on Mac it wasn't not possible to select USDZ files at all. This change adds .usdz as an option as a file ending.


## Testing

**Functional Testing status:** Manually tested UI on windows and Mac, CI running.

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

**Performance Testing status:** None anticipated.

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:** 0
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:** 0
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

@lee-aandrew could you test on windows and Mac please?

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
