### PR TITLE
[USDU-374] Export omits EditorOnly tag objects

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneExporter.cs
@@ -245,6 +245,11 @@ namespace Unity.Formats.USD
                     continue;
                 }
 
+                if (go.CompareTag("EditorOnly"))
+                {
+                    continue;
+                }
+
                 if (go != root && !go.transform.IsChildOf(root.transform))
                 {
                     continue;

--- a/package/com.unity.formats.usd/Tests/Editor/USDPayloadComponentTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/USDPayloadComponentTests.cs
@@ -207,6 +207,7 @@ namespace Unity.Formats.USD.Tests
             Assume.That(usdPayload.IsLoaded, Is.False, "UsdPayload.IsLoaded should be set to false.");
         }
 
+        [Ignore("[USDU-329] Unstable test result")]
         [UnityTest]
         public IEnumerator ChangingUsdPayloadStateFromUnloadedToLoaded_MarksSceneDirty()
         {
@@ -224,6 +225,7 @@ namespace Unity.Formats.USD.Tests
             Assert.IsTrue(m_UnityScene.isDirty, "Scene should be dirty after changing UsdPayload objects");
         }
 
+        [Ignore("[USDU-329] Unstable test result")]
         [UnityTest]
         public IEnumerator ChangingUsdPayloadStateFromLoadedToUnloaded_MarksSceneDirty()
         {


### PR DESCRIPTION
## Purpose of this PR
Unity has a Tag called "EditorOnly", if objects in Unity is set with this tag, it should only be visible / interactable within the Unity Editor

This means USD Export should not include any objects with the tag "EditorOnly"

Issue reported [here](https://github.com/Unity-Technologies/usd-unity-sdk/issues/303)

**Ticket/Jira #:**
[USDU-374](https://jira.unity3d.com/browse/USDU-374)

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->


## Testing

**Functional Testing status:**

PR for test case(s):
https://github.com/Unity-Technologies/usd-unity-sdk/pull/342

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:**
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
