### PR TITLE
[draft] [USDU-370] First pass at adding relative path to UsdAsset.

### DIFF
--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdAssetEditor.cs
@@ -229,7 +229,7 @@ namespace Unity.Formats.USD
             {
                 string lastDir;
                 if (string.IsNullOrEmpty(usdAsset.usdFullPath))
-                    lastDir = System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments);
+                    lastDir = Application.dataPath;
                 else
                     lastDir = Path.GetDirectoryName(usdAsset.usdFullPath);
                 string importFilepath =
@@ -343,8 +343,15 @@ namespace Unity.Formats.USD
             stageRoot.StateToOptions(ref options);
             var parent = stageRoot.gameObject.transform.parent;
             var root = parent ? parent.gameObject : null;
-            stageRoot.ImportUsdAsCoroutine(root, stageRoot.usdFullPath, stageRoot.m_usdTimeOffset, options,
-                targetFrameMilliseconds: 5);
+            if (stageRoot.IsAssetPathValid())
+            {
+                stageRoot.ImportUsdAsCoroutine(root, stageRoot.usdFullPath, stageRoot.m_usdTimeOffset, options,
+                    targetFrameMilliseconds: 5);
+            }
+            else
+            {
+                Debug.LogWarning($"USD Asset path for `{stageRoot.name}` is invalid. Check that the path <{stageRoot.usdFullPath}> exists.");
+            }
         }
     }
 }

--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdLayerStackEditor.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdLayerStackEditor.cs
@@ -43,6 +43,13 @@ namespace Unity.Formats.USD
             if (GUILayout.Button("Save Layer Stack"))
             {
                 InitUsd.Initialize();
+                var usdAsset = layerStack.GetComponent<UsdAsset>();
+                if (!usdAsset.IsAssetPathValid())
+                {
+                    Debug.LogWarning($"USD Asset path for `{usdAsset.name}` is invalid.");
+                    return;
+                }
+
                 Scene scene = Scene.Open(layerStack.GetComponent<UsdAsset>().usdFullPath);
                 try
                 {

--- a/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdPrimSourceEditor.cs
+++ b/package/com.unity.formats.usd/Editor/Scripts/Behaviors/UsdPrimSourceEditor.cs
@@ -43,7 +43,7 @@ namespace Unity.Formats.USD
             }
 
             var scene = stageRoot.GetScene();
-            if (scene == null)
+            if (scene == null || !stageRoot.IsAssetPathValid())
             {
                 Debug.LogError("Invalid scene: " + stageRoot.usdFullPath);
                 return;

--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
@@ -29,6 +29,13 @@ namespace Unity.Formats.USD
     [ExecuteInEditMode]
     public class UsdAsset : MonoBehaviour
     {
+        enum USDPathType
+        {
+            Unknown,
+            External,
+            Relative
+        }
+
         /// <summary>
         /// The length of the USD playback time in seconds.
         /// </summary>
@@ -39,23 +46,64 @@ namespace Unity.Formats.USD
 
         /// <summary>
         /// The absolute file path to the USD file from which this asset was created. This path may
-        /// point to a location outside of the Unity project and may be any file type supported by
-        /// USD (e.g. usd, usda, usdc, abc, ...). Setting this path will not trigger the asset to be
-        /// reimported, Reload must be called explicitly.
+        /// be any file type supported by USD (e.g. usd, usda, usdc, abc, ...). Setting this path
+        /// will not trigger the asset to be reimported, Reload must be called explicitly.
+        /// While files external to the project folder are supported, they are not recommended as the
+        /// project will have errors when shared or moved.
         /// </summary>
         public string usdFullPath
         {
-            get { return string.IsNullOrEmpty(m_usdFile) ? string.Empty : (Path.GetFullPath(m_usdFile)); }
-            set { m_usdFile = value; }
+            get
+            {
+                switch (m_usdFilePathType)
+                {
+                    case USDPathType.Relative:
+                        // if we already have a relative path, return it
+                        return Path.GetFullPath(m_relativeUSDPath);
+                    case USDPathType.External:
+                        // if we know the path is external, try to use it
+                        return string.IsNullOrEmpty(m_usdFile) ? string.Empty : m_usdFile;
+                    case USDPathType.Unknown:
+                        // if we haven't inspected the path yet, do it now
+                        AttemptUSDPathFixup();
+                        if (!string.IsNullOrEmpty(m_relativeUSDPath))
+                            return Path.GetFullPath(m_relativeUSDPath);
+                        else
+                            return string.IsNullOrEmpty(m_usdFile) ? string.Empty : m_usdFile;
+                    default:
+                        return string.Empty;
+                }
+            }
+            set
+            {
+                m_relativeUSDPath = DetermineRelativePathFromFullPath(value);
+                m_usdFilePathType = USDPathType.Relative;
+
+                if (string.IsNullOrEmpty(m_relativeUSDPath))
+                {
+                    Debug.Log("USD file path provided is not within the Project folder. You may encounter errors if this project is later shared.");
+                    m_relativeUSDPath = string.Empty;
+                    m_usdFile = Path.IsPathRooted(value) ? value : Path.GetFullPath(value);
+                    m_usdFilePathType = USDPathType.External;
+                }
+            }
         }
 
         // ----------------------------------------------------------------------------------------- //
         // Source Asset.
         // ----------------------------------------------------------------------------------------- //
 
+        // Wherever possible, use m_relativeUSDPath instead
         [Header("Source Asset")]
         [SerializeField]
         string m_usdFile;
+
+        [SerializeField]
+        string m_relativeUSDPath;
+
+        // do not serialize so that we can try to fix paths on domain reload
+        [NonSerialized]
+        USDPathType m_usdFilePathType = USDPathType.Unknown;
 
         [HideInInspector]
         [Tooltip("The Unity project path into which imported files (such as textures) will be placed.")]
@@ -209,6 +257,69 @@ namespace Unity.Formats.USD
         }
 
 #endif
+        public bool IsAssetPathValid()
+        {
+            if (string.IsNullOrEmpty(usdFullPath))
+                return false;
+            if (!File.Exists(usdFullPath))
+                return false;
+            return true;
+        }
+
+        /// <summary>
+        /// Converts inputPath to a Relative Path, if the inputPath is inside the Project folder. If the path is not inside the project folder, returns empty string.
+        /// </summary>
+        /// <param name="inputPath">
+        /// The path to determine a path relative to the project folder from. We assume the inputPath is a full path, else this will fail.
+        /// </param>
+        private string DetermineRelativePathFromFullPath(string inputPath)
+        {
+            string pathLower = inputPath.ToLower().Replace('\\', '/');
+            string projectPath = System.IO.Directory.GetCurrentDirectory().ToLower().Replace('\\', '/'); // VRC: This might only be correct in editor- check this
+
+            if (pathLower.StartsWith(projectPath))
+            {
+                return inputPath.Substring(projectPath.Length + 1); // plus 1 for the trailing seperator
+            }
+
+            return string.Empty;
+        }
+
+
+        /// <summary>
+        /// Attempt to fix an m_usdPath, which could previously be relative or external, to a relative path.
+        /// If the path is not inside the project folder, leave it.
+        /// </summary>
+        /// <remarks>
+        /// This method does *not* determine whether a path exists or not. It is down to the user to make sure the path exists,
+        /// else it will error later.
+        /// </remarks>
+        private void AttemptUSDPathFixup()
+        {
+            if (!string.IsNullOrEmpty(m_relativeUSDPath))
+            {
+                m_usdFilePathType = USDPathType.Relative;
+                return;
+            }
+            else if (string.IsNullOrEmpty(m_usdFile))
+            {
+                return;
+            }
+
+            // set the m_usdFile var to contain full path in case it is external, and clear it later if it's not.
+            m_usdFile = Path.IsPathRooted(m_usdFile) ? m_usdFile : Path.GetFullPath(m_usdFile);
+            m_relativeUSDPath = DetermineRelativePathFromFullPath(m_usdFile);
+
+            if (!string.IsNullOrEmpty(m_relativeUSDPath))
+            {
+                m_usdFile = string.Empty;
+                m_usdFilePathType = USDPathType.Relative;
+            }
+            else
+            {
+                m_usdFilePathType = USDPathType.External;
+            }
+        }
 
         private void OnDestroy()
         {
@@ -370,7 +481,7 @@ namespace Unity.Formats.USD
             if (m_lastScene?.Stage == null || SceneFileChanged())
             {
                 pxr.UsdStage stage = null;
-                if (string.IsNullOrEmpty(usdFullPath))
+                if (!IsAssetPathValid())
                 {
                     return null;
                 }
@@ -776,6 +887,7 @@ namespace Unity.Formats.USD
             SceneImportOptions importOptions,
             float targetFrameMilliseconds)
         {
+            // TODO: this would be much cleaner if we just used the path and time member variables, but that would be a breaking API change
             InitUsd.Initialize();
             var scene = Scene.Open(usdFilePath);
             if (scene == null)

--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdLayerStack.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdLayerStack.cs
@@ -89,10 +89,16 @@ namespace Unity.Formats.USD
                 throw new NullReferenceException("Could not create layer: " + m_targetLayer);
             }
 
+            if (!stageRoot.IsAssetPathValid())
+            {
+                Debug.LogWarning($"Asset path for {stageRoot.name} invalid.");
+                return;
+            }
+
             Scene rootScene = Scene.Open(stageRoot.usdFullPath);
             if (rootScene == null)
             {
-                throw new NullReferenceException("Could not open base layer: " + stageRoot.usdFullPath);
+                throw new NullReferenceException($"Could not open base layer: <{stageRoot.usdFullPath}>");
             }
 
             SetupNewSubLayer(rootScene, subLayerScene);


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** [USDU-370]

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->

When Unity project directories are moved or shared, the full path that is serialized for an imported asset causes lots of errors due to the path being different. This change attempts to, where possible, save only the relative path inside the Unity project folder, but still fallback to the full path when it's not in the project folder. We then also catch cases more cleanly when they don't exist at the stated path. This awkward code is necessary to not break existing projects when upgrading, and still support importing USD files from outside the project folder.

We could alternatively have a one time fix up style approach that happens on domain reload or something, but this seemed the simplest approach that should catch if the user fixes a missing file.

This version will be **non backwards compatible**, because the UsdAsset is 'fixed' to contain a m_relativeUsdPath, and this new field doesn't exist on older versions of the package. As many users have had too many issues with 3.0.0-exp.2 that 3.0.0-exp.3 should solve, this shouldn't be too common. However I think we should fully discuss this before landing.

## Testing

**Functional Testing status:**

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

TBC

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

TBC

We are adding potential overhead to a getter which is certainly undesirable, however in the majority of cases it should fallback to the same cost as before- a single call to Path.GetFullPath().

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:** Low
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:** Medium
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
