### PR TITLE
Adds Define Constraints for the editor assembly files

### DIFF
--- a/package/com.unity.formats.usd/Samples/ExportMesh/Editor/Unity.Formats.USD.ExportMesh.Editor.asmdef
+++ b/package/com.unity.formats.usd/Samples/ExportMesh/Editor/Unity.Formats.USD.ExportMesh.Editor.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Unity.Formats.USD.ExportMesh.Editor",
+    "rootNamespace": "",
     "references": [
         "Unity.Formats.USD.ExportMesh"
     ],
@@ -11,7 +12,9 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/package/com.unity.formats.usd/Samples/ImportMesh/Editor/Unity.Formats.USD.ImportMeshEditor.asmdef
+++ b/package/com.unity.formats.usd/Samples/ImportMesh/Editor/Unity.Formats.USD.ImportMeshEditor.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Unity.Formats.USD.ImportMeshEditor",
+    "rootNamespace": "",
     "references": [
         "Unity.Formats.USD.ImportMesh",
         "Unity.Formats.USD.Runtime",
@@ -10,10 +11,12 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/package/com.unity.formats.usd/Samples/ImportMesh/Editor/Unity.Formats.USD.ImportMeshEditor.asmdef
+++ b/package/com.unity.formats.usd/Samples/ImportMesh/Editor/Unity.Formats.USD.ImportMeshEditor.asmdef
@@ -11,7 +11,7 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": true,
+    "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [


### PR DESCRIPTION
## Purpose of this PR
Adds Define Constraints for the editor assembly files
The Editor assembly files that were added last push were missing the define constraints required

**Ticket/Jira #:**

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->


## Testing

**Functional Testing status:**

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:**
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**
Now that i think about it, i dont know why our samples' assembly definitions have the "UNITY_INCLUDE_TESTS" Define constraints when they arent tests - we should perhaps delete the constraint or have a different constraint such as "USD_SAMPLES"

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
