### PR TITLE
[USDU-438] Fix export from project folder

### DIFF
--- a/package/com.unity.formats.usd/CHANGELOG.md
+++ b/package/com.unity.formats.usd/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changes in usd-unity-sdk for Unity
 
+## [3.0.0-exp.5] - Unreleased
+### Features
+
+### Bug Fixes
+- Fixed export for Prefabs from the Project Window.
+
+### Changed
+
 ## [3.0.0-exp.4] - 2023-06-21
 ### Features
 - Added EditorAnalytics to track internally which features are most used.

--- a/package/com.unity.formats.usd/Dependencies/USD.NET.Unity/UnityTypeConverter.cs
+++ b/package/com.unity.formats.usd/Dependencies/USD.NET.Unity/UnityTypeConverter.cs
@@ -291,6 +291,10 @@ namespace USD.NET.Unity
         {
             if (transform.parent == null)
             {
+                // When exporting prefabs from project window, scene is null.
+                // If the GameObject doesn't have a parent, it can't have any siblings anyway.
+                if (!transform.gameObject.scene.IsValid())
+                    return false;
                 return transform.gameObject.scene.GetRootGameObjects().Any(sibling => sibling != transform.gameObject && sibling.name == name);
             }
 

--- a/package/com.unity.formats.usd/Tests/Editor/Data/Prefabs.meta
+++ b/package/com.unity.formats.usd/Tests/Editor/Data/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82188d14333cffe45a7b0586f04c9f00
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/Editor/Data/Prefabs/TestPrefab.prefab
+++ b/package/com.unity.formats.usd/Tests/Editor/Data/Prefabs/TestPrefab.prefab
@@ -1,0 +1,189 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1123661221660330672
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1582040728665274192}
+  - component: {fileID: 7765216584708699925}
+  - component: {fileID: 3927384668714606523}
+  - component: {fileID: 4324230398523533352}
+  m_Layer: 0
+  m_Name: TestPrefab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1582040728665274192
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1123661221660330672}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5426644795844415577}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7765216584708699925
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1123661221660330672}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3927384668714606523
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1123661221660330672}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &4324230398523533352
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1123661221660330672}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &5673467655074520046
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5426644795844415577}
+  - component: {fileID: 2139844036812997987}
+  - component: {fileID: 6449456054199424237}
+  - component: {fileID: 6825181994790301044}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5426644795844415577
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5673467655074520046}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.89, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1582040728665274192}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2139844036812997987
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5673467655074520046}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6449456054199424237
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5673467655074520046}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!135 &6825181994790301044
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5673467655074520046}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/package/com.unity.formats.usd/Tests/Editor/Data/Prefabs/TestPrefab.prefab.meta
+++ b/package/com.unity.formats.usd/Tests/Editor/Data/Prefabs/TestPrefab.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 90633c08c7035c74aab77931779245bd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package/com.unity.formats.usd/Tests/Editor/ExportTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/ExportTests.cs
@@ -178,5 +178,31 @@ namespace Unity.Formats.USD.Tests
             var expectedSkeletonInUsdType = new pxr.TfToken("Skeleton");
             Assert.AreEqual(expectedSkeletonInUsdType, skeletonInUsdType);
         }
+
+        [Test]
+        public void ExportPrefabFromProjectWindow_ExportsWithoutErrors()
+        {
+            // "Packages/com.unity.formats.usd/Tests/Editor/Data/Prefabs/TestPrefab.prefab"
+            // When running the tests on CI usd package paths get changed and the Prefab can't be loaded by path
+            var testPrefabGUID = "90633c08c7035c74aab77931779245bd";
+            var testPrefabPath = AssetDatabase.GUIDToAssetPath(testPrefabGUID);
+            var testPrefabGO = AssetDatabase.LoadMainAssetAtPath(testPrefabPath) as GameObject;
+
+            // Export without instantiating into the Scene
+            ExportHelpers.ExportGameObjects(new GameObject[] { testPrefabGO }, ExportHelpers.InitForSave(m_USDScenePath), BasisTransformation.SlowAndSafe);
+
+            m_USDScene = Scene.Open(m_USDScenePath);
+
+            var rootTestPrefabPrim = m_USDScene.Stage.GetPrimAtPath(new pxr.SdfPath(UnityTypeConverter.GetPath(testPrefabGO.transform)));
+            var rootTestPrefabPrimType = rootTestPrefabPrim.GetTypeName();
+            var expectedRootInUsdType = new pxr.TfToken("Mesh");
+            Assert.AreEqual(expectedRootInUsdType, rootTestPrefabPrimType);
+
+
+            var childTestPrefabPrim = m_USDScene.Stage.GetPrimAtPath(new pxr.SdfPath(UnityTypeConverter.GetPath(testPrefabGO.transform.GetChild(0))));
+            var childTestPrefabPrimType = childTestPrefabPrim.GetTypeName();
+            var expectedChildInUsdType = new pxr.TfToken("Mesh");
+            Assert.AreEqual(expectedChildInUsdType, childTestPrefabPrimType);
+        }
     }
 }


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** #395 / [USDU-438](https://jira.unity3d.com/browse/USDU-438)

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->

The fix for not allowing multiple objects with the same name introduced a check for any siblings of an object having the same name. In the case of a root GameObject, it uses the scene the GO is in to find any siblings. If it is not in a scene (as is the case for a Prefab selected in the project window), this scene is null and the export fails with an error.

This PR adds a simple check for whether the Scene is valid. I believe it is fine to early out in this case, because having two files with the same name selected in the project view doesn't seem to be possible.

There is a weird edge case where perhaps a user exports two prefabs with the same name through script. I haven't figured out a fix for that case yet.

## Testing

**Functional Testing status:**

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

Added a new automated test case, manually verified fix. Testing flagged a separate issue with exporting skeletons from a prefab, so I raised a [ticket](https://jira.unity3d.com/browse/USDU-439) for that.

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

Shouldn't have any impact on performance.

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:** 1
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:** 1
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
