### PR TITLE
[USDU-427] Adds Additional tests for import as prefab option

### DIFF
--- a/package/com.unity.formats.usd/Tests/Common/CustomAsserts/ImportAssert.cs
+++ b/package/com.unity.formats.usd/Tests/Common/CustomAsserts/ImportAssert.cs
@@ -29,7 +29,31 @@ namespace Unity.Formats.USD.Tests
                 UsdPrimSource = 3
             }
 
-            public static void IsValidImport(Object[] usdAsObjects, int expectedGameObjectCount, int expectedPrimSourceCount, int expectedMaterialCount)
+            public static void IsValidGameObjectImport(GameObject rootObject, int expectedPrimSourceCount, int expectedMeshCount)
+            {
+                Assert.IsNotNull(rootObject.GetComponent<UsdAsset>());
+
+                var actualPrimSourceCount = 1; // root has one
+                var actualMeshCount = 0;
+
+                foreach (Transform child in rootObject.transform)
+                {
+                    if (child.GetComponent<UsdPrimSource>() != null)
+                    {
+                        actualPrimSourceCount++;
+                    }
+
+                    if (child.GetComponent<MeshRenderer>() != null)
+                    {
+                        actualMeshCount++;
+                    }
+                }
+
+                Assert.AreEqual(expectedPrimSourceCount, actualPrimSourceCount, "Expected PrimSource count does not match the actual PrimSource count.");
+                Assert.AreEqual(expectedMeshCount, actualMeshCount, "Expected Mesh count does not match the actual Mesh count.");
+            }
+
+            public static void IsValidPrefabImport(Object[] usdAsObjects, int expectedGameObjectCount, int expectedPrimSourceCount, int expectedMaterialCount)
             {
                 Assert.NotZero(usdAsObjects.Length);
 

--- a/package/com.unity.formats.usd/Tests/Editor/ImportHelpersTests.cs
+++ b/package/com.unity.formats.usd/Tests/Editor/ImportHelpersTests.cs
@@ -143,7 +143,18 @@ namespace Unity.Formats.USD.Tests
             // ExpectedGameObjectCount: The Root GameObject + Sphere GameObject added
             // ExpectedPrimSourceCount: Root Source + Sphere Source
             // ExpectedMaterialCount: The 3 default materials + 1 material from Sphere meshRender
-            ImportAssert.Editor.IsValidImport(usdAsObjects, expectedGameObjectCount: 2, expectedPrimSourceCount: 2, expectedMaterialCount: 4);
+            ImportAssert.Editor.IsValidPrefabImport(usdAsObjects, expectedGameObjectCount: 2, expectedPrimSourceCount: 2, expectedMaterialCount: 4);
+        }
+
+        [Test]
+        public void ImportAsGameObjectTest_SimpleFile_ContentOk()
+        {
+            var scene = TestUtility.CreateTestUsdScene(ArtifactsDirectoryFullPath);
+            var importedGameObject = ImportHelpers.ImportSceneAsGameObject(scene);
+
+            // ExpectedPrimSourceCount: Root Source + Sphere Source
+            // ExpectedMeshCount: Sphere Mesh
+            ImportAssert.Editor.IsValidGameObjectImport(importedGameObject, expectedPrimSourceCount: 2, expectedMeshCount: 1);
         }
 
         [Test]
@@ -155,10 +166,21 @@ namespace Unity.Formats.USD.Tests
             Assert.IsTrue(File.Exists(assetPath));
             var usdAsObjects = AssetDatabase.LoadAllAssetsAtPath(assetPath);
 
-            // ExpectedGameObjectCount: The Root GameObject + Box GameObjects added
-            // ExpectedPrimSourceCount: Root Source + Boxes Source
-            // ExpectedMaterialCount: The 3 default materials + 1 material from Box meshRender + 1 from grid
-            ImportAssert.Editor.IsValidImport(usdAsObjects, expectedGameObjectCount: 25, expectedPrimSourceCount: 25, expectedMaterialCount: 5);
+            // ExpectedGameObjectCount: The Root GameObject + 24 Cube GameObjects added
+            // ExpectedPrimSourceCount: Root Source + 24 Cube PrimSources
+            // ExpectedMaterialCount: The 3 default materials + 1 material from Cube meshRender + 1 from Grid Object
+            ImportAssert.Editor.IsValidPrefabImport(usdAsObjects, expectedGameObjectCount: 25, expectedPrimSourceCount: 25, expectedMaterialCount: 5);
+        }
+
+        [Test]
+        public void ImportAsGameObjectTest_VariedCollection_ContentOk()
+        {
+            var scene = TestUtility.OpenUSDSceneWithGUID(TestDataGuids.VariedCollection.AttributeScopeUsda);
+            var importedGameObject = ImportHelpers.ImportSceneAsGameObject(scene);
+
+            // ExpectedPrimSourceCount: Root Source + 24 various cube objects
+            // ExpectedMeshCount: 24 cube meshes
+            ImportAssert.Editor.IsValidGameObjectImport(importedGameObject, expectedPrimSourceCount: 25, expectedMeshCount: 24);
         }
 
         public void ImportAsTimelineClipTest_ContentOk()
@@ -173,7 +195,7 @@ namespace Unity.Formats.USD.Tests
             // ExpectedGameObjectCount: The Root GameObject
             // ExpectedPrimSourceCount: 0 TODO: Shouldnt there be a prim source object for the root object?
             // ExpectedMaterialCount: The 3 default materials
-            ImportAssert.Editor.IsValidImport(usdAsObjects, expectedGameObjectCount: 1, expectedPrimSourceCount: 0, expectedMaterialCount: 3);
+            ImportAssert.Editor.IsValidPrefabImport(usdAsObjects, expectedGameObjectCount: 1, expectedPrimSourceCount: 0, expectedMaterialCount: 3);
         }
 
         public void ImportAsPrefab_TextureDataImported()


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:**

[USDU-427](https://jira.unity3d.com/browse/USDU-427)
We had a crash on one of the versions of Unity, but our automated tests did not catch it
Turns out we don't import a certain type of USD as a prefab, which causes the crash 
Added test cases that import a usd file that contains various different attributes of USD both as a GameObject and a prefab

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->

## Testing

**Functional Testing status:**

Adds the following:
- ImportAsGameObjectTest_VariedCollection_ContentOk
- ImportAsPrefabTest_VariedCollection_ContentOk

Changes:
- ImportInstancerAsGameObject_VertexCheck to ImportInstancer_VertexCheck
-- Tests for both GameObject and Prefab imports now

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:**
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
