### PR TITLE
[USDU-472] Fix USD component removal on Prefabs

### DIFF
--- a/package/com.unity.formats.usd/CHANGELOG.md
+++ b/package/com.unity.formats.usd/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 - Fixed export for Prefabs from the Project Window.
 - Fixed export of URP base and occlusion maps for Lit shader.
+- Fixed USD component removal workflows for Prefabs.
 
 ### Changed
 - Renamed USD.md in the Documentation folder to index.md to match documentation generation standards for landing pages.

--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
@@ -16,6 +16,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.IO;
+using UnityEditor;
 using UnityEngine;
 using USD.NET;
 using USD.NET.Unity;
@@ -453,7 +454,7 @@ namespace Unity.Formats.USD
                 return;
             }
 
-            Component.DestroyImmediate(comp);
+            Component.DestroyImmediate(comp, true);
         }
 
         /// <summary>
@@ -472,6 +473,7 @@ namespace Unity.Formats.USD
         /// </summary>
         public void RemoveAllUsdComponents()
         {
+            UnityEditor.Undo.RegisterFullObjectHierarchyUndo(this, "Clear USD");
             foreach (var src in GetComponentsInChildren<UsdPrimSource>(includeInactive: true))
             {
                 if (src)
@@ -493,6 +495,7 @@ namespace Unity.Formats.USD
         /// </summary>
         public void DestroyAllImportedObjects()
         {
+            UnityEditor.Undo.RegisterFullObjectHierarchyUndo(this, "Delete USD objects");
             foreach (var src in GetComponentsInChildren<UsdPrimSource>(includeInactive: true))
             {
                 // Remove the object if it is valid, but never remove the UsdAsset root GameObject, which
@@ -500,7 +503,7 @@ namespace Unity.Formats.USD
                 // stubs of USD Assets can be left in the scene in the scene and imported only as needed.
                 if (src && src.gameObject != this.gameObject)
                 {
-                    GameObject.DestroyImmediate(src.gameObject);
+                    GameObject.DestroyImmediate(src.gameObject, true);
                 }
             }
         }

--- a/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/Behaviors/UsdAsset.cs
@@ -473,7 +473,9 @@ namespace Unity.Formats.USD
         /// </summary>
         public void RemoveAllUsdComponents()
         {
-            UnityEditor.Undo.RegisterFullObjectHierarchyUndo(this, "Clear USD");
+#if UNITY_EDITOR
+            Undo.RegisterFullObjectHierarchyUndo(this, "Remove USD components");
+#endif
             foreach (var src in GetComponentsInChildren<UsdPrimSource>(includeInactive: true))
             {
                 if (src)
@@ -495,7 +497,9 @@ namespace Unity.Formats.USD
         /// </summary>
         public void DestroyAllImportedObjects()
         {
-            UnityEditor.Undo.RegisterFullObjectHierarchyUndo(this, "Delete USD objects");
+#if UNITY_EDITOR
+            Undo.RegisterFullObjectHierarchyUndo(this, "Delete USD imported objects");
+#endif
             foreach (var src in GetComponentsInChildren<UsdPrimSource>(includeInactive: true))
             {
                 // Remove the object if it is valid, but never remove the UsdAsset root GameObject, which

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Scene/SceneImporter.cs
@@ -388,7 +388,7 @@ namespace Unity.Formats.USD
                 return;
             }
 #if UNITY_EDITOR
-            Component.DestroyImmediate(c);
+            Component.DestroyImmediate(c, true);
 #else
             Component.Destroy(c);
 #endif


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** #405 / [USDU-472](https://jira.unity3d.com/browse/USDU-472)

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->

There were bugs in the 'detach USD' and 'remove USD' workflows for Prefabs that this PR fixes:
1. When editing the Prefab Asset from the Project Window, both of these workflows resulted in errors because we were not forcing the 'DestroyImmediate' to destroy assets.
2. When editing the Prefab Asset in prefab editing mode, these workflows did not set the scene as dirty, so the changes were not saved and therefore not persisting. This change registers the action as undo-able, with the side effect of tracking changes to trigger the scene-save.

## Testing

**Functional Testing status:**

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

Tested locally that all four expected situations act as expected:
1. Import as Game Object -> remove components should work
2. Import as Prefab -> open in Inspector from Project Window -> remove components should work, instances of the prefab should have same change
3. Import as Prefab -> open in Prefab Editing mode -> remove components should work, instances of the prefab should have same change
4. Import as Prefab -> add instance to scene and modify this instance -> should not be able to make destructive changes.

@nicolaspopravka confirmed on #405 that this fixes the issue for them :) 

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

There may be a slight increase in time taken for the removal process, but before it wasn't doing the expected work so this is unavoidable.

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:** low
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:** low
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [x] Add entry in CHANGELOG.md _(if applicable)_
