### PR TITLE
[USDU-347] Fix for export of Diffuse Color when a base map is set on material.

### DIFF
--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/StandardShaderExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/StandardShaderExporter.cs
@@ -340,7 +340,8 @@ namespace Unity.Formats.USD
                     "rgb");
                 surface.diffuseColor.SetConnectedPath(newTex);
             }
-            else if (mat.HasProperty("_Color"))
+            
+            if (mat.HasProperty("_Color"))
             {
                 // Standard.
                 c = mat.GetColor("_Color").linear;

--- a/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/StandardShaderExporter.cs
+++ b/package/com.unity.formats.usd/Runtime/Scripts/IO/Materials/StandardShaderExporter.cs
@@ -340,7 +340,7 @@ namespace Unity.Formats.USD
                     "rgb");
                 surface.diffuseColor.SetConnectedPath(newTex);
             }
-            
+
             if (mat.HasProperty("_Color"))
             {
                 // Standard.


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** [USDU-347](https://jira.unity3d.com/browse/USDU-347)

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->

This PR means that both the diffuse texture and the diffuse colour will both be exported to USD. As the default in Unity is white, this shouldn't have an impact on the result when it's not set. 

The bug repro actually describes a round trip, which is *not* fixed by this PR. This is because I'm not sure whether we should be importing both the texture and the colour from USD. The default color in Unity is white (1,1,1), whereas in USD the default value for diffuseColor is [grey](https://openusd.org/release/spec_usdpreviewsurface.html)(0.18 ,0.18, 0.18). Currently the import behaviour is to try to import a connected texture (ie a base map), and if it isn't available, fallback to importing a uniform diffuse color. If we were to switch this to always import the diffuseColor even when there is a base map, I think we could end up breaking some cases as once inside Unity they would have this grey applied. But I'm not sure, this is a complicated topic with no clear documentation on how/ when the color is combined with the map or not in USD. Maybe that default is only set when there is no base map, in which case it would be fine. I think it's too high risk to change when the Importer package already seems to handle it (I tested importing my exported test with map + color and both were imported there).

**_Doesn't yet include HDRP but I want opinions before I go ahead with that_**
## Testing

**Functional Testing status:**

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

Tested manually that a GameObject with a material with both a texture and a colour set appeared the same in USDView. 

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

Very tiny impact of now exporting two attributes.

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:** low
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:** low
<!-- (Minimal / Low / Medium / High) -->

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [ ] Add entry in CHANGELOG.md _(if applicable)_
